### PR TITLE
fixed support for mutli images

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -549,9 +549,9 @@ async function doMakeImage(reqBody) {
             seedField.disabled = false
         })
 
-        imgSaveBtn.addEventListener('click', function() {
+        imgSaveBtn.addEventListener('click', function(e) {
             let imgDownload = document.createElement('a')
-            imgDownload.download = createFileName();
+            imgDownload.download = createFileName(e);
             imgDownload.href = imgBody
             imgDownload.click()
         })
@@ -658,37 +658,49 @@ async function makeImage() {
 
 // create a file name with embedded prompt and metadata
 // for easier cateloging and comparison
-function createFileName() {
-
-    // Most important information is the prompt
+function createFileName(e) {
+    // create a file name with underscores
     const underscoreName = promptField.value.replace(/[^a-zA-Z0-9]/g, '_');
-    const seed = seedField.value;
-    const steps = numInferenceStepsField.value;
-    const guidance =  guidanceScaleField.value; 
-
     // name and the top level metadata
-    let fileName = `sd_${underscoreName}_Seed-${seed}_Steps-${steps}_Guidance-${guidance}`;
+    let fileName = `sd_${underscoreName}`
 
     // add the tags
     let tags = [];
     let tagString = '';
-    document.querySelectorAll(modifyTagsSelector).forEach(function(tag) {
-        tags.push(tag.innerHTML);
-    })
 
     // join the tags with a pipe
-    if (tags.length > 0) {
-        tagString = '_Tags:';
-        tagString += tags.join('|');
+    if (activeTags.length > 0) {
+        tagString = ',Tags:';
+        activeTags.sort((a, b) => a.toLowerCase() < b.toLowerCase() ? -1 : 1);
+        tagString += activeTags.join('|');
     }
 
     // append empty or populated tags
     fileName += `${tagString}`;
 
+    const seed = fileSeedHelper(e);
+    const steps = numInferenceStepsField.value;
+    const guidance =  guidanceScaleField.value; 
+    let MetaData = `,Seed:${seed},Steps:${steps},Guidance:${guidance},Size:${widthField.value}x${heightField.value}`;
+
+    // add the metadata
+    fileName += `${MetaData}`;
+
     // add the file extension
     fileName += `.png`;
 
     return fileName;
+}
+
+function fileSeedHelper(e) {
+    const target = e.target;
+    // get the imgSeedLabel element that is the sibling of the target
+    const seedLabel = target.parentElement.querySelector('.imgSeedLabel');
+    // get the seed value  from the imgSeedLabel element 
+    let seedInt = parseInt(seedLabel.innerText.split(':')[1], 10); 
+    // is that is a number, then use it otherwise use the seedField value
+    const seed = !isNaN(seedInt) ? seedInt : seedField.value;
+    return seed;
 }
 
 function handleAudioEnabledChange(e) {


### PR DESCRIPTION
I didn't expect you to merge that PR so quickly, as I was doing some more testing. I realized I missed an edge case. I was pulled the seed value from the input and that would be wrong if you generated 2+ images. 

This new implementation adjust the logic to get the seed value from the label that is sibling to the download button. 

I also adjusted a bit of the formatting, I added the dimensions, which you could get by inspecting, but having it in the file name seemed nicer. I also  replaced the underscores with commas since I felt like that made more sense. 

Took a quick look to see if this was going to mess up the auto download but that still works fine.

