### PR TITLE
Add shebangs to all sh files

### DIFF
--- a/scripts/on_env_start.sh
+++ b/scripts/on_env_start.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 printf "\n\nStable Diffusion UI\n\n"
 
 if [ -f "scripts/install_status.txt" ] && [ `grep -c sd_ui_git_cloned scripts/install_status.txt` -gt "0" ]; then

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 cp sd-ui-files/scripts/on_env_start.sh scripts/
 
 source installer/etc/profile.d/conda.sh

--- a/scripts/post_activate.sh
+++ b/scripts/post_activate.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 conda-unpack
 
 source $CONDA_PREFIX/etc/profile.d/conda.sh

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 source installer/bin/activate
 
 conda-unpack


### PR DESCRIPTION
Add `#!/bin/bash` to all `.sh` files.

This is generally always a good idea, as it forces the sh files to run in a specific shell (in this case bash), which prevents the scripts crashing out when someone runs it from a different shell.