### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,13 +19,14 @@ This is in-flux, but one way to get a development environment running for editin
 4) Check you can view and generate images on `localhost:9000`
 5) Close the server, and edit `/projects/stable-diffusion-ui-archive/scripts/on_env_start.sh`
 6) Comment out the line near the bottom that copies the `files/ui` folder, e.g. `cp -Rf sd-ui-files/ui ui` for `.sh` or `@xcopy sd-ui-files\ui ui /s /i /Y` for `.bat`
-7) Delete the current `ui` folder at `/projects/stable-diffusion-ui-archive/ui`
+7) Delete the current `ui` folder at `/projects/stable-diffusion-ui-archive/sd-ui-files/ui`
 8) Now make a symlink between the repository clone (where you will be making changes) and this archive (where you will be running stable diffusion):
-`ln -s /projects/stable-diffusion-ui-repo/ui /projects/stable-diffusion-ui-archive/ui`
+`ln -s /projects/stable-diffusion-ui-repo/ui /projects/stable-diffusion-ui-archive/sd-ui-files/ui`
 or for Windows
 `mklink /D \projects\stable-diffusion-ui-archive\ui \projects\stable-diffusion-ui-repo\ui` (link name first, source repo dir second)
-9) Run the archive again `start.sh` and ensure you can still use the UI.
-10) Congrats, now any changes you make in your repo `ui` folder are linked to this running archive of the app and can be previewed in the browser.
+9) From the archive directory root, for e.g.,  `/projects/stable-diffusion-ui-archive`, run `./stable-diffusion/env/bin/pip install -e ./stable-diffusion` in order to prevent a circular import error. 
+10) Run the archive again `start.sh` and ensure you can still use the UI.
+11) Congrats, now any changes you make in your repo `ui` folder are linked to this running archive of the app and can be previewed in the browser.
 
 Check the `ui/frontend/build/README.md` for instructions on running and building the React code.
 


### PR DESCRIPTION
Add extra step to avoid circular import error for developers.  This needs to be fixed at the script level eventually, or imports need to be reordered.  

Additionally, modified some steps to add clarity as the instructions provided result in the `ui` files constantly being blown away by the `git reset` activity.  

```python
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/jay/programs/stablediffusion/stable-diffusion-ui/stable-diffusion/optimizedSD/openaimodelS
plit.py", line 16, in <module>
    from splitAttention import SpatialTransformer
ModuleNotFoundError: No module named 'splitAttention'
```