### PR TITLE
fix: change to the correct working directory

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 source installer/bin/activate
 
 conda-unpack


### PR DESCRIPTION
changes to the directory containing `start.sh` prior to activating the conda environment

this allows you to run the program without first changing to the correct directory, eg: `$ ~/bin/stable-diffusion-ui/start.sh`