### PR TITLE
Minor css change for the tiny modifier cards

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -343,16 +343,13 @@
     .modifier-card-size_-3 .modifier-card-image-overlay {
         font-size: 3em;
     }
-    .modifier-card-size_-3 p {
-        font-size: 0.8em;
-    }
     .modifier-card-tiny {
         width: 6em;
         height: 9.5em;
         grid-template-rows: 6em 3.5em;
     }
-    .modifier-card-tiny p {
-        font-size: 0.7em;
+    .modifier-card-tiny .modifier-card-image-overlay {
+        font-size: 4em;
     }
     .modifier-card:hover {
         transform: scale(1.05);


### PR DESCRIPTION
This change ensures that the minus sign doesn't change size for the tiny cards, after the user has changed the card sizes. Nothing major, but will be more pleasing to look at.