### PR TITLE
Restrict UI to localhost

### DIFF
--- a/scripts/on_sd_start.bat
+++ b/scripts/on_sd_start.bat
@@ -312,6 +312,6 @@ call WHERE uvicorn > .tmp
 
 @call python --version
 
-@uvicorn server:app --app-dir "%SD_UI_PATH%" --port 9000 --host 0.0.0.0
+@uvicorn server:app --app-dir "%SD_UI_PATH%" --port 9000 --host 127.0.0.1
 
 @pause

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -304,6 +304,6 @@ cd stable-diffusion
 
 python --version
 
-uvicorn server:app --app-dir "$SD_UI_PATH" --port 9000 --host 0.0.0.0
+uvicorn server:app --app-dir "$SD_UI_PATH" --port 9000 --host 127.0.0.1
 
 read -p "Press any key to continue"


### PR DESCRIPTION
It might not be wise to have the Stable Diffusion UI running on public Internet considering it has the ability to create directories & save random photos.

This restricts the access to localhost only.