### PR TITLE
Resize in-painting disable

### DIFF
--- a/ui/media/main.js
+++ b/ui/media/main.js
@@ -1140,6 +1140,7 @@ initImageClearBtn.addEventListener('click', function() {
 
 maskSetting.addEventListener('click', function() {
     inpaintingEditorContainer.style.display = (this.checked ? 'block' : 'none')
+    resizeInpaintingEditor()
 })
 
 promptsFromFileBtn.addEventListener('click', function() {

--- a/ui/media/main.js
+++ b/ui/media/main.js
@@ -279,6 +279,11 @@ function resizeInpaintingEditor() {
         widthValue = (widthValue / heightValue) * INPAINTING_EDITOR_SIZE
         heightValue = INPAINTING_EDITOR_SIZE
     }
+    if (inpaintingEditor.opts.aspectRatio === (widthValue / heightValue).toFixed(3)) {
+        // Same ratio, don't reset the canvas.
+        return
+    }
+    inpaintingEditor.opts.aspectRatio = (widthValue / heightValue).toFixed(3)
 
     inpaintingEditorContainer.style.width = widthValue + 'px'
     inpaintingEditorContainer.style.height = heightValue + 'px'

--- a/ui/media/main.js
+++ b/ui/media/main.js
@@ -264,6 +264,9 @@ async function healthCheck() {
     }
 }
 function resizeInpaintingEditor() {
+    if (!maskSetting.checked) {
+        return
+    }
     let widthValue = parseInt(widthField.value)
     let heightValue = parseInt(heightField.value)
     if (widthValue === heightValue) {


### PR DESCRIPTION
Disable 'resizeInpaintingEditor' when 'maskSetting' is unchecked and run 'resizeInpaintingEditor' once when 'maskSetting' is changed in case the aspect ratio was changed while 'resizeInpaintingEditor' was hidden.