### PR TITLE
async ping locks on load_model_ckpt, avoid lock at start by preloading model before browser open

### DIFF
--- a/ui/server.py
+++ b/ui/server.py
@@ -333,6 +333,8 @@ async def start_browser():
     # ping once to load the model before opening the browser
     # avoid opening the browser when the FastApp server is locked loading a new model
     await ping()
+    # added sleep to avoid intermitent timeout error.
+    await asyncio.sleep(1)
     # start the browser ui
     import webbrowser
     webbrowser.open('http://localhost:9000')


### PR DESCRIPTION
`async def ping():` will lock on `load_model_ckpt` as the method loading the model is not async.
To avoid the lock at the start we could preload the model before calling browser open.

[Src](https://dev.to/ruarfff/understanding-python-async-with-fastapi-42hn): `If you don't specify your endpoint as being async i.e. as [a coroutine](https://docs.python.org/3/library/asyncio-task.html), FastAPI will look after it for you instead as it will assume this route contains blocking calls whereas if you specify async, it's up to you to make sure it really is asynchronous.
`