### PR TITLE
Force encoding to utf-8 on text file operations Fixes #332

### DIFF
--- a/ui/sd_internal/runtime.py
+++ b/ui/sd_internal/runtime.py
@@ -541,7 +541,7 @@ Negative Prompt: {req.negative_prompt}
 Stable Diffusion Model: {req.use_stable_diffusion_model + '.ckpt'}
 """
     try:
-        with open(meta_out_path, 'w') as f:
+        with open(meta_out_path, 'w', encoding='utf-8') as f:
             f.write(metadata)
     except:
         print('could not save the file', traceback.format_exc())

--- a/ui/server.py
+++ b/ui/server.py
@@ -187,13 +187,13 @@ async def setAppConfig(req : SetAppConfigRequest):
         config_bat_path = os.path.join(CONFIG_DIR, 'config.bat')
         config_sh_path = os.path.join(CONFIG_DIR, 'config.sh')
 
-        with open(config_json_path, 'w') as f:
+        with open(config_json_path, 'w', encoding='utf-8') as f:
             f.write(config_json_str)
 
-        with open(config_bat_path, 'w') as f:
+        with open(config_bat_path, 'w', encoding='utf-8') as f:
             f.write(config_bat_str)
 
-        with open(config_sh_path, 'w') as f:
+        with open(config_sh_path, 'w', encoding='utf-8') as f:
             f.write(config_sh_str)
 
         return {'OK'}
@@ -206,7 +206,7 @@ def getConfig(default_val={}):
         config_json_path = os.path.join(CONFIG_DIR, 'config.json')
         if not os.path.exists(config_json_path):
             return default_val
-        with open(config_json_path, 'r') as f:
+        with open(config_json_path, 'r', encoding='utf-8') as f:
             return json.load(f)
     except Exception as e:
         print(str(e))
@@ -216,7 +216,7 @@ def getConfig(default_val={}):
 def setConfig(config):
     try:
         config_json_path = os.path.join(CONFIG_DIR, 'config.json')
-        with open(config_json_path, 'w') as f:
+        with open(config_json_path, 'w', encoding='utf-8') as f:
             return json.dump(config, f)
     except:
         print(str(e))


### PR DESCRIPTION
Fix for https://github.com/cmdr2/stable-diffusion-ui/issues/332
Force open to use encoding utf-8 for text file operations. Fixes systems where the default is another encoding.