### PR TITLE
fixed img_id for parallel renders

### DIFF
--- a/ui/sd_internal/runtime.py
+++ b/ui/sd_internal/runtime.py
@@ -197,7 +197,7 @@ def load_model_real_esrgan(real_esrgan_to_use):
 
     print('loaded ', real_esrgan_to_use, 'to', device, 'precision', precision)
 
-def get_base_path(disk_path, session_id, prompt, img_id, ext, suffix=None):
+def get_base_path(disk_path, session_id, prompt, ext, suffix=None):
     if disk_path is None: return None
     if session_id is None: return None
     if ext is None: raise Exception('Missing ext')
@@ -206,6 +206,8 @@ def get_base_path(disk_path, session_id, prompt, img_id, ext, suffix=None):
     os.makedirs(session_out_path, exist_ok=True)
 
     prompt_flattened = filename_regex.sub('_', prompt)[:50]
+    img_id = base64.b64encode(int(time.time()).to_bytes(8, 'big')).decode() # Generate unique ID based on time.
+    img_id = img_id.translate({43:None, 47:None, 61:None})[-8:] # Remove + / = and keep last 8 chars.
 
     if suffix is not None:
         return os.path.join(session_out_path, f"{prompt_flattened}_{img_id}_{suffix}.{ext}")
@@ -316,8 +318,7 @@ def do_mk_img(req: Request):
     opt_f = 8
     opt_ddim_eta = 0.0
     opt_init_img = req.init_image
-    img_id = base64.b64encode(int(time.time()).to_bytes(8, 'big')).decode() # Generate unique ID based on time.
-    img_id = img_id.translate({43:None, 47:None, 61:None})[-8:] # Remove + / = and keep last 8 chars.
+    
 
     print(req.to_string(), '\n    device', device)
 
@@ -479,9 +480,9 @@ def do_mk_img(req: Request):
 
                         if req.save_to_disk_path is not None:
                             if return_orig_img:
-                                img_out_path = get_base_path(req.save_to_disk_path, req.session_id, prompts[0], img_id, req.output_format)
+                                img_out_path = get_base_path(req.save_to_disk_path, req.session_id, prompts[0], req.output_format)
                                 save_image(img, img_out_path)
-                            meta_out_path = get_base_path(req.save_to_disk_path, req.session_id, prompts[0], img_id, 'txt')
+                            meta_out_path = get_base_path(req.save_to_disk_path, req.session_id, prompts[0], 'txt')
                             save_metadata(meta_out_path, req, prompts[0], opt_seed)
 
                         if return_orig_img:
@@ -508,7 +509,7 @@ def do_mk_img(req: Request):
                                 response_image = ResponseImage(data=filtered_img_data, seed=req.seed)
                                 res.images.append(response_image)
                                 if req.save_to_disk_path is not None:
-                                    filtered_img_out_path = get_base_path(req.save_to_disk_path, req.session_id, prompts[0], img_id, req.output_format, "_".join(filters_applied))
+                                    filtered_img_out_path = get_base_path(req.save_to_disk_path, req.session_id, prompts[0], req.output_format, "_".join(filters_applied))
                                     save_image(filtered_image, filtered_img_out_path)
                                     response_image.path_abs = filtered_img_out_path
                                 del filtered_image

--- a/ui/sd_internal/runtime.py
+++ b/ui/sd_internal/runtime.py
@@ -197,7 +197,7 @@ def load_model_real_esrgan(real_esrgan_to_use):
 
     print('loaded ', real_esrgan_to_use, 'to', device, 'precision', precision)
 
-def get_base_path(disk_path, session_id, prompt, ext, suffix=None):
+def get_base_path(disk_path, session_id, prompt, img_id, ext, suffix=None):
     if disk_path is None: return None
     if session_id is None: return None
     if ext is None: raise Exception('Missing ext')
@@ -206,8 +206,7 @@ def get_base_path(disk_path, session_id, prompt, ext, suffix=None):
     os.makedirs(session_out_path, exist_ok=True)
 
     prompt_flattened = filename_regex.sub('_', prompt)[:50]
-    img_id = base64.b64encode(int(time.time()).to_bytes(8, 'big')).decode() # Generate unique ID based on time.
-    img_id = img_id.translate({43:None, 47:None, 61:None})[-8:] # Remove + / = and keep last 8 chars.
+    
 
     if suffix is not None:
         return os.path.join(session_out_path, f"{prompt_flattened}_{img_id}_{suffix}.{ext}")
@@ -463,6 +462,8 @@ def do_mk_img(req: Request):
 
                     print("saving images")
                     for i in range(batch_size):
+                        img_id = base64.b64encode(int(time.time()+i).to_bytes(8, 'big')).decode() # Generate unique ID based on time.
+                        img_id = img_id.translate({43:None, 47:None, 61:None})[-8:] # Remove + / = and keep last 8 chars.
 
                         x_samples_ddim = modelFS.decode_first_stage(x_samples[i].unsqueeze(0))
                         x_sample = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
@@ -480,9 +481,9 @@ def do_mk_img(req: Request):
 
                         if req.save_to_disk_path is not None:
                             if return_orig_img:
-                                img_out_path = get_base_path(req.save_to_disk_path, req.session_id, prompts[0], req.output_format)
+                                img_out_path = get_base_path(req.save_to_disk_path, req.session_id, prompts[0], img_id, req.output_format)
                                 save_image(img, img_out_path)
-                            meta_out_path = get_base_path(req.save_to_disk_path, req.session_id, prompts[0], 'txt')
+                            meta_out_path = get_base_path(req.save_to_disk_path, req.session_id, prompts[0], img_id, 'txt')
                             save_metadata(meta_out_path, req, prompts[0], opt_seed)
 
                         if return_orig_img:
@@ -509,7 +510,7 @@ def do_mk_img(req: Request):
                                 response_image = ResponseImage(data=filtered_img_data, seed=req.seed)
                                 res.images.append(response_image)
                                 if req.save_to_disk_path is not None:
-                                    filtered_img_out_path = get_base_path(req.save_to_disk_path, req.session_id, prompts[0], req.output_format, "_".join(filters_applied))
+                                    filtered_img_out_path = get_base_path(req.save_to_disk_path, req.session_id, prompts[0], img_id, req.output_format, "_".join(filters_applied))
                                     save_image(filtered_image, filtered_img_out_path)
                                     response_image.path_abs = filtered_img_out_path
                                 del filtered_image


### PR DESCRIPTION
img_id generation needs to be part of the for loop for batch generation, otherwise only the latest file of parallel renders will be saved.