### PR TITLE
Improved render response checks

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -522,7 +522,7 @@ async function doMakeImage(task) {
 
         if (typeof renderRequest?.stream !== 'string') {
             console.log('Endpoint response: ', renderRequest)
-            throw new Error('Endpoint response does not contains a response stream url.')
+            throw new Error(renderRequest.detail || 'Endpoint response does not contains a response stream url.')
         }
 
         task['taskStatusLabel'].innerText = "Waiting"

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -535,13 +535,23 @@ async function doMakeImage(task) {
                 throw new Error('Connexion with server lost.')
             }
         } while (Date.now() < (serverState.time + SERVER_STATE_VALIDITY_DURATION) && serverState.task !== renderRequest.task)
-
-        if (serverState.session !== 'pending' && serverState.session !== 'running' && serverState.session !== 'buffer') {
-            if (serverState.session === 'stopped') {
+        switch(serverState.session) {
+            case 'pending':
+            case 'running':
+            case 'buffer':
+                // Normal expected messages.
+                break
+            case 'completed':
+                console.warn('Server %o render request %o completed unexpectedly', serverState, renderRequest)
+                break // Continue anyway to try to read cached result.
+            case 'error':
+                console.error('Server %o render request %o has failed', serverState, renderRequest)
+                break // Still valid, Update UI with error message
+            case 'stopped':
+                console.log('Server %o render request %o was stopped', serverState, renderRequest)
                 return false
-            }
-
-            throw new Error('Unexpected server task state: ' + serverState.session || 'Undefined')
+            default:
+                throw new Error('Unexpected server task state: ' + serverState.session || 'Undefined')
         }
 
         while (serverState.task === renderRequest.task && serverState.session === 'pending') {

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -535,6 +535,7 @@ async function doMakeImage(task) {
                 throw new Error('Connexion with server lost.')
             }
         } while (Date.now() < (serverState.time + SERVER_STATE_VALIDITY_DURATION) && serverState.task !== renderRequest.task)
+
         switch(serverState.session) {
             case 'pending':
             case 'running':


### PR DESCRIPTION
Small improvement that should help with

Unexpected server task state: completed

Endpoint response does not contains a response stream url.

If not it will at a minimum increase logging and that should help to at least find the remaining issues.

Note: case 'error' has been validated to log properly now by making the backend crash using 'raise Exception()' in the render thread.