### PR TITLE
Fix TypeError: string indices must be integers

### DIFF
--- a/ui/sd_internal/runtime.py
+++ b/ui/sd_internal/runtime.py
@@ -622,8 +622,8 @@ def do_mk_img(req: Request):
                             save_metadata(meta_out_path, req, prompts[0], opt_seed)
 
                         if return_orig_img:
-                            img_data = img_to_base64_str(img, req.output_format)
-                            res_image_orig = ResponseImage(data=img_data, seed=opt_seed)
+                            img_str = img_to_base64_str(img, req.output_format)
+                            res_image_orig = ResponseImage(data=img_str, seed=opt_seed)
                             res.images.append(res_image_orig)
 
                             if req.save_to_disk_path is not None:


### PR DESCRIPTION
`Show only the corrected image` is now fixed. I missed that little detail... We were both using `img_data`.
Can't have two vars with the same name...