### PR TITLE
Improve error handling

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,7 @@ mkdir -p dist/linux-mac/stable-diffusion-ui/scripts
 
 cp scripts/on_env_start.sh dist/linux-mac/stable-diffusion-ui/scripts/
 cp scripts/bootstrap.sh dist/linux-mac/stable-diffusion-ui/scripts/
+cp scripts/functions.sh dist/linux-mac/stable-diffusion-ui/scripts/
 cp scripts/start.sh dist/linux-mac/stable-diffusion-ui/
 cp LICENSE dist/linux-mac/stable-diffusion-ui/
 cp "CreativeML Open RAIL-M License" dist/linux-mac/stable-diffusion-ui/

--- a/scripts/Start Stable Diffusion UI.cmd
+++ b/scripts/Start Stable Diffusion UI.cmd
@@ -1,5 +1,6 @@
 @echo off
 
+cd /d %~dp0
 set PATH=C:\Windows\System32;%PATH%
 
 @rem set legacy installer's PATH, if it exists

--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -37,6 +37,12 @@ if "%PACKAGES_TO_INSTALL%" NEQ "" (
         mkdir "%MAMBA_ROOT_PREFIX%"
         call curl -L "%MICROMAMBA_DOWNLOAD_URL%" > "%MAMBA_ROOT_PREFIX%\micromamba.exe"
 
+	if "%ERRORLEVEL%" NEQ "0" (
+	    echo "There was a problem downloading micromamba. Cannot continue."
+	    pause
+	    exit /b
+	)
+
         @rem test the mamba binary
         echo Micromamba version:
         call "%MAMBA_ROOT_PREFIX%\micromamba.exe" --version

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -3,7 +3,9 @@
 #
 
 fail() {
+    echo
     echo "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
+    echo
     if [ "$1" != "" ]; then
         echo ERROR: $1
     else

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,0 +1,30 @@
+#
+# utility functions for all scripts
+#
+
+fail() {
+    echo "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
+    if [ "$1" != "" ]; then
+        echo ERROR: $1
+    else
+        echo An error occurred.
+    fi
+    cat <<EOF
+
+Error downloading Stable Diffusion UI. Sorry about that, please try to:
+ 1. Run this installer again.
+ 2. If that doesn't fix it, please try the common troubleshooting steps at https://github.com/cmdr2/stable-diffusion-ui/wiki/Troubleshooting
+ 3. If those steps don't help, please copy *all* the error messages in this window, and ask the community at https://discord.com/invite/u9yhsFmEkB
+ 4. If that doesn't solve the problem, please file an issue at https://github.com/cmdr2/stable-diffusion-ui/issues
+
+Thanks!
+
+
+EOF
+    read -p "Press any key to continue"
+    exit 1
+
+}
+
+
+

--- a/scripts/on_env_start.sh
+++ b/scripts/on_env_start.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source ./scripts/functions.sh
+
 printf "\n\nStable Diffusion UI\n\n"
 
 if [ -f "scripts/config.sh" ]; then
@@ -27,9 +29,7 @@ else
     if git clone -b "$update_branch" https://github.com/cmdr2/stable-diffusion-ui.git sd-ui-files ; then
         echo sd_ui_git_cloned >> scripts/install_status.txt
     else
-        printf "\n\nError downloading Stable Diffusion UI. Sorry about that, please try to:\n  1. Run this installer again.\n  2. If that doesn't fix it, please try the common troubleshooting steps at https://github.com/cmdr2/stable-diffusion-ui/wiki/Troubleshooting\n  3. If those steps don't help, please copy *all* the error messages in this window, and ask the community at https://discord.com/invite/u9yhsFmEkB\n  4. If that doesn't solve the problem, please file an issue at https://github.com/cmdr2/stable-diffusion-ui/issues\nThanks!\n\n"
-        read -p "Press any key to continue"
-        exit
+        fail "git clone failed"
     fi
 fi
 

--- a/scripts/on_sd_start.bat
+++ b/scripts/on_sd_start.bat
@@ -343,6 +343,9 @@ call python --version
 @set SD_UI_PATH=%cd%\ui
 @cd stable-diffusion
 
-@uvicorn server:app --app-dir "%SD_UI_PATH%" --port 9000 --host 0.0.0.0
+@if NOT DEFINED SD_UI_BIND_PORT set SD_UI_BIND_PORT=9000
+@if NOT DEFINED SD_UI_BIND_IP set SD_UI_BIND_PORT=0.0.0.0
+@uvicorn server:app --app-dir "%SD_UI_PATH%" --port %SD_UI_BIND_PORT% --host %SD_UI_BIND_IP%
+
 
 @pause

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -283,6 +283,6 @@ cd ..
 export SD_UI_PATH=`pwd`/ui
 cd stable-diffusion
 
-uvicorn server:app --app-dir "$SD_UI_PATH" --port ${SDUI_BIND_PORT:-9000} --host ${SDUI_BIND_IP:-0.0.0.0}
+uvicorn server:app --app-dir "$SD_UI_PATH" --port ${SD_UI_BIND_PORT:-9000} --host ${SD_UI_BIND_IP:-0.0.0.0}
 
 read -p "Press any key to continue"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -6,17 +6,17 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 if [ -e "installer" ]; then export PATH="$(pwd)/installer/bin:$PATH"; fi
 
 # Setup the packages required for the installer
-scripts/bootstrap.sh
+scripts/bootstrap.sh || exit 1
 
 # set new installer's PATH, if it downloaded any packages
 if [ -e "installer_files/env" ]; then export PATH="$(pwd)/installer_files/env/bin:$PATH"; fi
 
 # Test the bootstrap
 which git
-git --version
+git --version || exit 1
 
 which conda
-conda --version
+conda --version || exit 1
 
 # Download the rest of the installer and UI
 scripts/on_env_start.sh

--- a/ui/sd_internal/runtime.py
+++ b/ui/sd_internal/runtime.py
@@ -685,11 +685,13 @@ def img_to_base64_str(img, output_format="PNG"):
     img.save(buffered, format=output_format)
     buffered.seek(0)
     img_byte = buffered.getvalue()
-    img_str = "data:image/png;base64," + base64.b64encode(img_byte).decode()
+    mime_type = "image/png" if output_format.lower() == "png" else "image/jpeg"
+    img_str = f"data:{mime_type};base64," + base64.b64encode(img_byte).decode()
     return img_str
 
 def base64_str_to_img(img_str):
-    img_str = img_str[len("data:image/png;base64,"):]
+    mime_type = "image/png" if img_str.startswith("data:image/png;") else "image/jpeg"
+    img_str = img_str[len(f"data:{mime_type};base64,"):]
     data = base64.b64decode(img_str)
     buffered = BytesIO(data)
     img = Image.open(buffered)


### PR DESCRIPTION
### Cross platform
- add env variables SD_UI_BIND_IP and SD_UI_BIND_PORT to configure uvicorn

### Linux
- Add error handling in bootstrap.sh
   - check whether the micromamba download was successful. Abort if it wasn't.
   - Return "1" in case of errors
   - In start.sh, abort if bootstrap.sh was not successful.
- Add an auxilliary file `functions.sh` with a `fail` function, reducing code duplication (#DRY)
- In start.sh, abort execution if git and conda don't work after running bootstrap.sh
- Add tips for common error sources (missing bzip2, missing libsm6 packages)
### Windows
- cd to the script location on start of 'Start Stable Diffusion UI.cmd' like in start.sh
- Bail out when downloading micromamba fails

https://discord.com/channels/1014774730907209781/1038438436081782784/1038438436081782784
Handling this issue took some turns. Identifying the root cause was difficult because the errors in bootstrap.sh didn't abort the execution of the installer.