### PR TITLE
Protect SD_UI_BIND_PORT and SD_UI_BIND_IP in config files

### DIFF
--- a/ui/server.py
+++ b/ui/server.py
@@ -120,9 +120,9 @@ def setConfig(config):
         config_bat_path = os.path.join(CONFIG_DIR, 'config.bat')
 
         if os.getenv('SD_UI_BIND_PORT') is not None:
-	    config_bat.append(f"@set SD_UI_BIND_PORT={os.getenv('SD_UI_BIND_PORT')}")
+            config_bat.append(f"@set SD_UI_BIND_PORT={os.getenv('SD_UI_BIND_PORT')}")
         if os.getenv('SD_UI_BIND_IP') is not None:
-	    config_bat.append(f"@set SD_UI_BIND_IP={os.getenv('SD_UI_BIND_IP')}")
+            config_bat.append(f"@set SD_UI_BIND_IP={os.getenv('SD_UI_BIND_IP')}")
 
 
         with open(config_bat_path, 'w', encoding='utf-8') as f:
@@ -146,9 +146,9 @@ def setConfig(config):
                 print('GPU:0 seems to be missing! Validate that CUDA_VISIBLE_DEVICES is set properly.')
 
         if os.getenv('SD_UI_BIND_PORT') is not None:
-	    config_sh.append(f"export SD_UI_BIND_PORT={os.getenv('SD_UI_BIND_PORT')}")
+            config_sh.append(f"export SD_UI_BIND_PORT={os.getenv('SD_UI_BIND_PORT')}")
         if os.getenv('SD_UI_BIND_IP') is not None:
-	    config_sh.append(f"export SD_UI_BIND_IP={os.getenv('SD_UI_BIND_IP')}")
+            config_sh.append(f"export SD_UI_BIND_IP={os.getenv('SD_UI_BIND_IP')}")
 
         config_sh_path = os.path.join(CONFIG_DIR, 'config.sh')
         with open(config_sh_path, 'w', encoding='utf-8') as f:

--- a/ui/server.py
+++ b/ui/server.py
@@ -107,6 +107,7 @@ def setConfig(config):
         config_bat = [
             f"@set update_branch={config['update_branch']}"
         ]
+
         if os.getenv('CUDA_VISIBLE_DEVICES') is None:
             if len(gpu_devices) > 0 and not has_first_cuda_device:
                 config_bat.append('::Set the devices visible inside SD-UI here')
@@ -117,6 +118,13 @@ def setConfig(config):
             if len(gpu_devices) > 0 and not has_first_cuda_device:
                 print('GPU:0 seems to be missing! Validate that CUDA_VISIBLE_DEVICES is set properly.')
         config_bat_path = os.path.join(CONFIG_DIR, 'config.bat')
+
+        if os.getenv('SD_UI_BIND_PORT') is not None:
+	    config_bat.append(f"@set SD_UI_BIND_PORT={os.getenv('SD_UI_BIND_PORT')}")
+        if os.getenv('SD_UI_BIND_IP') is not None:
+	    config_bat.append(f"@set SD_UI_BIND_IP={os.getenv('SD_UI_BIND_IP')}")
+
+
         with open(config_bat_path, 'w', encoding='utf-8') as f:
             f.write('\r\n'.join(config_bat))
     except Exception as e:
@@ -136,6 +144,12 @@ def setConfig(config):
             config_sh.append(f"export CUDA_VISIBLE_DEVICES=\"{os.getenv('CUDA_VISIBLE_DEVICES')}\"")
             if len(gpu_devices) > 0 and not has_first_cuda_device:
                 print('GPU:0 seems to be missing! Validate that CUDA_VISIBLE_DEVICES is set properly.')
+
+        if os.getenv('SD_UI_BIND_PORT') is not None:
+	    config_sh.append(f"export SD_UI_BIND_PORT={os.getenv('SD_UI_BIND_PORT')}")
+        if os.getenv('SD_UI_BIND_IP') is not None:
+	    config_sh.append(f"export SD_UI_BIND_IP={os.getenv('SD_UI_BIND_IP')}")
+
         config_sh_path = os.path.join(CONFIG_DIR, 'config.sh')
         with open(config_sh_path, 'w', encoding='utf-8') as f:
             f.write('\n'.join(config_sh))


### PR DESCRIPTION
Copy over SD_UI_BIND_PORT and SD_UI_BIND_IP variables when rewriting config.sh and config.bat.
See #445 for usage of these vars.

This PR is not part of #445 because the config file handling has been rewritten a lot in beta.