### PR TITLE
Fix: Uncaught TypeError: Cannot set properties of null

### DIFF
--- a/ui/media/js/utils.js
+++ b/ui/media/js/utils.js
@@ -31,10 +31,14 @@ function toggleCollapsible(element) {
     let content = getNextSibling(collapsibleHeader, '.collapsible-content')
     if (content.style.display === "block") {
         content.style.display = "none"
-        handle.innerHTML = '&#x2795;' // plus
+        if (handle != null) {  // render results don't have a handle
+            handle.innerHTML = '&#x2795;' // plus
+        }
     } else {
         content.style.display = "block"
-        handle.innerHTML = '&#x2796;' // minus
+        if (handle != null) {  // render results don't have a handle
+            handle.innerHTML = '&#x2796;' // minus
+        }
     }
     
     if (COLLAPSIBLES_INITIALIZED && COLLAPSIBLE_PANELS.includes(element)) {


### PR DESCRIPTION
The collapsible render results don't have a handle (+/-) like the image settings, so `handle` can be null.
This has no direct user impact, but causes errors to be logged to the console.