### PR TITLE
Fix undefined BIND_IP assigns port instead of ip

### DIFF
--- a/scripts/on_sd_start.bat
+++ b/scripts/on_sd_start.bat
@@ -352,8 +352,8 @@ call python --version
 @cd stable-diffusion
 
 @if NOT DEFINED SD_UI_BIND_PORT set SD_UI_BIND_PORT=9000
-@if NOT DEFINED SD_UI_BIND_IP set SD_UI_BIND_PORT=0.0.0.0
-@uvicorn server:app --app-dir "%SD_UI_PATH%" --port 9000 --host 0.0.0.0
+@if NOT DEFINED SD_UI_BIND_IP set SD_UI_BIND_IP=0.0.0.0
+@uvicorn server:app --app-dir "%SD_UI_PATH%" --port %SD_UI_BIND_PORT% --host %SD_UI_BIND_IP%
 
 
 @pause


### PR DESCRIPTION
For the Windows on_sd_start batch file: 

The variables added for SD_UI_BIND_IP and PORT were not being assigned properly when undefined, leading to possibly having an invalid port and undefined IP