### PR TITLE
prompt textbox - only vertical resize

### DIFF
--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -28,6 +28,7 @@ label {
     font-size: 13px;
     margin-bottom: 6px;
     margin-top: 5px;
+    resize: vertical;
 }
 .image_preview_container {
     margin-top: 10pt;


### PR DESCRIPTION
If the resize handle of the textbox is pulled under the result pane, the result pane will obscure that part of the textbox. The handle becomes unreachable and the user can't resize the textbox any more. 

https://discord.com/channels/1014774730907209781/1040411379691176026/1040414658554765402

In older versions of the UI, it was possible to make the textbox wider, and the result pane would become thinner:
![image](https://user-images.githubusercontent.com/5852422/201233725-8168b645-0dfa-4b05-8157-16ff3169d695.png)

Since this is no longer the case, horizontal resizing should be disabled.