### PR TITLE
set USERPROFILE to local profile (fixes #468)

### DIFF
--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -15,6 +15,9 @@ set umamba_exists=F
 set OLD_APPDATA=%APPDATA%
 set APPDATA=%cd%\installer_files\appdata
 
+@mkdir %cd%\profile
+set USERPROFILE=%cd%\profile
+
 @rem figure out whether git and conda needs to be installed
 if exist "%INSTALL_ENV_DIR%" set PATH=%INSTALL_ENV_DIR%;%INSTALL_ENV_DIR%\Library\bin;%INSTALL_ENV_DIR%\Scripts;%INSTALL_ENV_DIR%\Library\usr\bin;%PATH%
 


### PR DESCRIPTION
According to this analysis: https://discord.com/channels/1014774730907209781/1040225028828057620/1040324719074889779 the USERPROFILE variable must not contain unicode characters as well. Only setting APPDATA is not sufficient.