### PR TITLE
Add paste button next to copy button

### DIFF
--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -887,3 +887,7 @@ input::file-selector-button {
     margin-bottom: 15px;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.15), 0 6px 20px 0 rgba(0, 0, 0, 0.15);
 }
+
+i.active {
+    background: var(--accent-color);
+}

--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -430,6 +430,10 @@ function checkWriteToClipboardPermission (result) {
         copyIcon.innerHTML = `<span class="simple-tooltip right">Copy Image Settings</span>`
         copyIcon.addEventListener('click', (event) => {
             event.stopPropagation()
+	    // Add css class 'active'
+	    copyIcon.classList.add('active')
+	    // In 1000 ms remove the 'active' class
+	    asyncDelay(1000).then(() => copyIcon.classList.remove('active'))
             const uiState = readUI()
             TASK_REQ_NO_EXPORT.forEach((key) => delete uiState.reqBody[key])
             if (uiState.reqBody.init_image && !IMAGE_REGEX.test(uiState.reqBody.init_image)) {
@@ -446,6 +450,10 @@ function checkWriteToClipboardPermission (result) {
         pasteIcon.innerHTML = `<span class="simple-tooltip right">Paste Image Settings</span>`
         pasteIcon.addEventListener('click', (event) => {
             event.stopPropagation()
+	    // Add css class 'active'
+	    pasteIcon.classList.add('active')
+	    // In 1000 ms remove the 'active' class
+	    asyncDelay(1000).then(() => pasteIcon.classList.remove('active'))
             pasteFromClipboard()
         })
         resetSettings.parentNode.insertBefore(pasteIcon, resetSettings)


### PR DESCRIPTION
Adds a paste button next to the copy to clipboard button on top of the image settings.
The button accepts either JSON content or autosave sidecar text file content - the same
content that drag and drop accepts as input.