### PR TITLE
Changed update_render_threads to use SetAppConfigRequest.

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -803,7 +803,6 @@ function getCurrentUserRequest() {
             height: heightField.value,
             // allow_nsfw: allowNSFWField.checked,
             turbo: turboField.checked,
-            render_device: getCurrentRenderDeviceSelection(),
             use_full_precision: useFullPrecisionField.checked,
             use_stable_diffusion_model: stableDiffusionModelField.value,
             use_vae_model: vaeModelField.value,
@@ -837,19 +836,6 @@ function getCurrentUserRequest() {
         newTask.reqBody.use_upscale = upscaleModelField.value
     }
     return newTask
-}
-
-function getCurrentRenderDeviceSelection() {
-    let selectedGPUs = $('#use_gpus').val()
-
-    if (useCPUField.checked && !autoPickGPUsField.checked) {
-        return 'cpu'
-    }
-    if (autoPickGPUsField.checked || selectedGPUs.length == 0) {
-        return 'auto'
-    }
-
-    return selectedGPUs.join(',')
 }
 
 function makeImage() {
@@ -1165,6 +1151,19 @@ promptStrengthSlider.addEventListener('input', updatePromptStrength)
 promptStrengthField.addEventListener('input', updatePromptStrengthSlider)
 updatePromptStrength()
 
+function getCurrentRenderDeviceSelection() {
+    let selectedGPUs = $('#use_gpus').val()
+
+    if (useCPUField.checked && !autoPickGPUsField.checked) {
+        return 'cpu'
+    }
+    if (autoPickGPUsField.checked || selectedGPUs.length == 0) {
+        return 'auto'
+    }
+
+    return selectedGPUs.join(',')
+}
+
 useCPUField.addEventListener('click', function() {
     let gpuSettingEntry = getParameterSettingsEntry('use_gpus')
     let autoPickGPUSettingEntry = getParameterSettingsEntry('auto_pick_gpus')
@@ -1184,11 +1183,19 @@ useCPUField.addEventListener('click', function() {
         }
         gpuSettingEntry.style.display = (autoPickGPUsField.checked ? 'none' : '')
     }
+
+    changeAppConfig({
+        'render_devices': getCurrentRenderDeviceSelection()
+    })
 })
 
 useGPUsField.addEventListener('click', function() {
     let selectedGPUs = $('#use_gpus').val()
     autoPickGPUsField.checked = (selectedGPUs.length === 0)
+
+    changeAppConfig({
+        'render_devices': getCurrentRenderDeviceSelection()
+    })
 })
 
 autoPickGPUsField.addEventListener('click', function() {
@@ -1198,6 +1205,10 @@ autoPickGPUsField.addEventListener('click', function() {
 
     let gpuSettingEntry = getParameterSettingsEntry('use_gpus')
     gpuSettingEntry.style.display = (this.checked ? 'none' : '')
+
+    changeAppConfig({
+        'render_devices': getCurrentRenderDeviceSelection()
+    })
 })
 
 async function changeAppConfig(configDelta) {

--- a/ui/sd_internal/device_manager.py
+++ b/ui/sd_internal/device_manager.py
@@ -13,10 +13,12 @@ def get_device_delta(render_devices, active_devices):
     active_devices: ['cpu', 'cuda:N'...]
     '''
 
-    if render_devices is not None:
-        if render_devices in ('cpu', 'auto'):
+    if render_devices in ('cpu', 'auto'):
+        render_devices = [render_devices]
+    elif render_devices is not None:
+        if isinstance(render_devices, str):
             render_devices = [render_devices]
-        elif isinstance(render_devices, list) and len(render_devices) > 0:
+        if isinstance(render_devices, list) and len(render_devices) > 0:
             render_devices = list(filter(lambda x: x.startswith('cuda:'), render_devices))
             if len(render_devices) == 0:
                 raise Exception('Invalid render_devices value in config.json. Valid: {"render_devices": ["cuda:0", "cuda:1"...]}, or {"render_devices": "cpu"} or {"render_devices": "auto"}')

--- a/ui/sd_internal/task_manager.py
+++ b/ui/sd_internal/task_manager.py
@@ -40,7 +40,7 @@ class RenderTask(): # Task with output queue and completion lock.
     def __init__(self, req: Request):
         self.request: Request = req # Initial Request
         self.response: Any = None # Copy of the last reponse
-        self.render_device = None # Select the task afinity. (Not used to change active devices).
+        self.render_device = None # Select the task affinity. (Not used to change active devices).
         self.temp_images:list = [None] * req.num_outputs * (1 if req.show_only_filtered_image else 2)
         self.error: Exception = None
         self.lock: threading.Lock = threading.Lock() # Locks at task start and unlocks when task is completed
@@ -72,7 +72,7 @@ class ImageRequest(BaseModel):
     save_to_disk_path: str = None
     turbo: bool = True
     use_cpu: bool = False ##TODO Remove after UI and plugins transition.
-    render_device: str = None
+    render_device: str = None # Select the task affinity. (Not used to change active devices).
     use_full_precision: bool = False
     use_face_correction: str = None # or "GFPGANv1.3"
     use_upscale: str = None # or "RealESRGAN_x4plus" or "RealESRGAN_x4plus_anime_6B"

--- a/ui/sd_internal/task_manager.py
+++ b/ui/sd_internal/task_manager.py
@@ -40,7 +40,7 @@ class RenderTask(): # Task with output queue and completion lock.
     def __init__(self, req: Request):
         self.request: Request = req # Initial Request
         self.response: Any = None # Copy of the last reponse
-        self.render_device = None
+        self.render_device = None # Select the task afinity. (Not used to change active devices).
         self.temp_images:list = [None] * req.num_outputs * (1 if req.show_only_filtered_image else 2)
         self.error: Exception = None
         self.lock: threading.Lock = threading.Lock() # Locks at task start and unlocks when task is completed
@@ -72,7 +72,7 @@ class ImageRequest(BaseModel):
     save_to_disk_path: str = None
     turbo: bool = True
     use_cpu: bool = False ##TODO Remove after UI and plugins transition.
-    render_device: str = 'auto'
+    render_device: str = None
     use_full_precision: bool = False
     use_face_correction: str = None # or "GFPGANv1.3"
     use_upscale: str = None # or "RealESRGAN_x4plus" or "RealESRGAN_x4plus_anime_6B"

--- a/ui/server.py
+++ b/ui/server.py
@@ -162,7 +162,6 @@ async def setAppConfig(req : SetAppConfigRequest):
     if req.update_branch:
         config['update_branch'] = req.update_branch
     if req.render_devices:
-        config['render_devices'] = req.render_devices
         update_render_threads_from_request(req.render_devices)
     try:
         setConfig(config)


### PR DESCRIPTION
Changed update_render_threads to use SetAppConfigRequest to set which devices are active.
Keep ImageRequest.render_device for affinity only. (Send a task to an already active device.)