### PR TITLE
Handle %TMP% and %TEMP%

### DIFF
--- a/scripts/on_sd_start.bat
+++ b/scripts/on_sd_start.bat
@@ -1,5 +1,8 @@
 @echo off
 
+@REM Caution, this file will make your eyes and brain bleed. It's such an unholy mess.
+@REM Note to self: Please rewrite this in Python. For the sake of your own sanity.
+
 @copy sd-ui-files\scripts\on_env_start.bat scripts\ /Y
 @copy sd-ui-files\scripts\bootstrap.bat scripts\ /Y
 
@@ -7,11 +10,17 @@ if exist "%cd%\profile" (
     set USERPROFILE=%cd%\profile
 )
 
+@mkdir tmp
+@set TMP=%cd%\tmp
+@set TEMP=%cd%\tmp
+
 @rem activate the installer env
 call conda activate
-
-@REM Caution, this file will make your eyes and brain bleed. It's such an unholy mess.
-@REM Note to self: Please rewrite this in Python. For the sake of your own sanity.
+@if "%ERRORLEVEL%" NEQ "0" (
+        @echo. & echo "Error activating conda for Stable Diffusion. Sorry about that, please try to:" & echo "  1. Run this installer again." & echo "  2. If that doesn't fix it, please try the common troubleshooting steps at https://github.com/cmdr2/stable-diffusion-ui/wiki/Troubleshooting" & echo "  3. If those steps don't help, please copy *all* the error messages in this window, and ask the community at https://discord.com/invite/u9yhsFmEkB" & echo "  4. If that doesn't solve the problem, please file an issue at https://github.com/cmdr2/stable-diffusion-ui/issues" & echo "Thanks!" & echo.
+        pause
+        exit /b
+)
 
 @REM remove the old version of the dev console script, if it's still present
 if exist "Open Developer Console.cmd" del "Open Developer Console.cmd"
@@ -68,8 +77,6 @@ if exist "Open Developer Console.cmd" del "Open Developer Console.cmd"
     @set PYTHONNOUSERSITE=1
 
     set USERPROFILE=%cd%\profile
-    set TMP=%cd%\tmp
-    set TEMP=%cd%\tmp
 
     set PYTHONPATH=%cd%;%cd%\env\lib\site-packages
 
@@ -107,8 +114,6 @@ set PATH=C:\Windows\System32;%PATH%
     @set PYTHONNOUSERSITE=1
 
     set USERPROFILE=%cd%\profile
-    set TMP=%cd%\tmp
-    set TEMP=%cd%\tmp
 
     set PYTHONPATH=%cd%;%cd%\env\lib\site-packages
 
@@ -142,8 +147,6 @@ set PATH=C:\Windows\System32;%PATH%
     @set PYTHONNOUSERSITE=1
 
     set USERPROFILE=%cd%\profile
-    set TMP=%cd%\tmp
-    set TEMP=%cd%\tmp
 
     set PYTHONPATH=%cd%;%cd%\env\lib\site-packages
 
@@ -171,8 +174,6 @@ set PATH=C:\Windows\System32;%PATH%
     @set PYTHONNOUSERSITE=1
 
     set USERPROFILE=%cd%\profile
-    set TMP=%cd%\tmp
-    set TEMP=%cd%\tmp
 
     set PYTHONPATH=%cd%;%cd%\env\lib\site-packages
 


### PR DESCRIPTION
`conda activate` fails if %TMP% or %TEMP% contains spaces. So instead of setting the temp variables in the installer steps, we need to set it at the beginning of the script. 

Would this break anything? 
https://discord.com/channels/1014774730907209781/1042190192049668106/1042190192049668106