### PR TITLE
Add Change history

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,8 @@
+# Change history
+
+Please add all changes that have a noticeable impact on users (including plugin
+developers) to this change list
+
+# 2.4.5
+* Add checkbox for "Open browser on startup"
+* Add a directory for core plugins that ship with Stable Diffusion UI by default

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ or for Windows
 `mklink /J \projects\stable-diffusion-ui-archive\ui \projects\stable-diffusion-ui-repo\ui` (link name first, source repo dir second)
 9) Run the project again (like in step 2) and ensure you can still use the UI.
 10) Congrats, now any changes you make in your repo `ui` folder are linked to this running archive of the app and can be previewed in the browser.
+11) Please update CHANGES.md in your pull requests.
 
 Check the `ui/frontend/build/README.md` for instructions on running and building the React code.
 


### PR DESCRIPTION
Release notes are important to inform users about added functionality. A change history will make it easier for the release coordinator to compile release notes, instead of having to go through all the commits (several hundred for the last release).