### PR TITLE
Textarea for negative prompts

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -54,7 +54,7 @@
                         <small>(optional)</small>
                     </label>
                     <div class="collapsible-content">
-                        <input id="negative_prompt" name="negative_prompt" placeholder="list the things to remove from the image (e.g. fog, green)">
+                        <textarea id="negative_prompt" name="negative_prompt" placeholder="list the things to remove from the image (e.g. fog, green)"></textarea>
                     </div>
                 </div>
 

--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -30,6 +30,14 @@ label {
     margin-top: 5px;
     display: block;
 }
+#negative_prompt {
+    width: 100%;
+    height: 50pt;
+    font-size: 9px;
+    margin-bottom: 5px;
+    margin-top: 5px;
+    display: block;
+}
 .image_preview_container {
     margin-top: 10pt;
 }


### PR DESCRIPTION
Use a textarea instead of an input field for the negative prompt. Negative prompts can become quite long and editing them in a single line is difficult. 