### PR TITLE
Link to the troubleshooting guide if there are problems importing GFPGANer

### DIFF
--- a/ui/sd_internal/runtime.py
+++ b/ui/sd_internal/runtime.py
@@ -24,7 +24,27 @@ from ldm.util import instantiate_from_config
 from optimizedSD.optimUtils import split_weighted_subprompts
 from transformers import logging
 
-from gfpgan import GFPGANer
+try:
+    from gfpgan import GFPGANer
+except Exception as e:
+    import rich
+    rich.print(traceback.format_exc())
+    rich.print(str(e))
+    rich.print()
+    rich.print("[bold red]ModuleNotFoundError: No module named 'gfpgan'[/bold red]")
+    rich.print()
+    rich.print("[bold yellow]This is a fatal error.[/bold yellow]")
+    rich.print()
+    rich.print("[bold yellow]If you've moved the Stable Diffusion UI installation to a different location, please follow[/bold yellow]")
+    rich.print("[bold yellow]the instructions in the troubleshooting guide at:[/bold yellow]")
+    print("https://github.com/cmdr2/stable-diffusion-ui/wiki/Troubleshooting#modulenotfounderror-no-module-named-gfpgan")
+    rich.print()
+    rich.print("[bold white on blue]  Press Enter to open the troubleshooting guide...  [/bold white on blue]")
+    input('')
+    import webbrowser; webbrowser.open('https://github.com/cmdr2/stable-diffusion-ui/wiki/Troubleshooting#modulenotfounderror-no-module-named-gfpgan')
+    raise(e)
+
+    
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from realesrgan import RealESRGANer
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5852422/202320464-17029b47-d9e4-41fa-aba8-c43d8905b5c6.png)

The `input()` call is needed since uvicorn will print long stack traces that would cover the above error message.