### PR TITLE
Add --whitespace=fix to git apply

### DIFF
--- a/scripts/on_sd_start.bat
+++ b/scripts/on_sd_start.bat
@@ -28,8 +28,8 @@ if exist "Open Developer Console.cmd" del "Open Developer Console.cmd"
     @call git pull
     @call git -c advice.detachedHead=false checkout f6cfebffa752ee11a7b07497b8529d5971de916c
 
-    @call git apply ..\ui\sd_internal\ddim_callback.patch
-    @call git apply ..\ui\sd_internal\env_yaml.patch
+    @call git apply --whitespace=fix ..\ui\sd_internal\ddim_callback.patch
+    @call git apply --whitespace=fix ..\ui\sd_internal\env_yaml.patch
 
     @cd ..
 ) else (
@@ -46,8 +46,8 @@ if exist "Open Developer Console.cmd" del "Open Developer Console.cmd"
     @cd stable-diffusion
     @call git -c advice.detachedHead=false checkout f6cfebffa752ee11a7b07497b8529d5971de916c
 
-    @call git apply ..\ui\sd_internal\ddim_callback.patch
-    @call git apply ..\ui\sd_internal\env_yaml.patch
+    @call git apply --whitespace=fix ..\ui\sd_internal\ddim_callback.patch
+    @call git apply --whitespace=fix ..\ui\sd_internal\env_yaml.patch
 
     @cd ..
 )

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -30,8 +30,8 @@ if [ -e "scripts/install_status.txt" ] && [ `grep -c sd_git_cloned scripts/insta
     git pull
     git -c advice.detachedHead=false checkout f6cfebffa752ee11a7b07497b8529d5971de916c
 
-    git apply ../ui/sd_internal/ddim_callback.patch || fail "ddim patch failed"
-    git apply ../ui/sd_internal/env_yaml.patch || fail "yaml patch failed"
+    git apply --whitespace=fix ../ui/sd_internal/ddim_callback.patch || fail "ddim patch failed"
+    git apply --whitespace=fix ../ui/sd_internal/env_yaml.patch || fail "yaml patch failed"
 
     cd ..
 else
@@ -46,8 +46,8 @@ else
     cd stable-diffusion
     git -c advice.detachedHead=false checkout f6cfebffa752ee11a7b07497b8529d5971de916c
 
-    git apply ../ui/sd_internal/ddim_callback.patch || fail "ddim patch failed"
-    git apply ../ui/sd_internal/env_yaml.patch || fail "yaml patch failed"
+    git apply --whitespace=fix ../ui/sd_internal/ddim_callback.patch || fail "ddim patch failed"
+    git apply --whitespace=fix ../ui/sd_internal/env_yaml.patch || fail "yaml patch failed"
 
     cd ..
 fi


### PR DESCRIPTION
For some users who have git preinstalled, `git apply` fails due to whitespace errors.

Aracon found that applying `--whitespace=fix` to the `git apply` invocation fixes the problem.
https://discord.com/channels/1014774730907209781/1036679816713359471/1037025435491516548

ryz confirmed further down in the same thread that `--reject` wasn't needed for him to make it work, and this explanation from the "git apply" manpage suggests that we shouldn't include `--reject`:

> For atomicity, git apply by default fails the whole patch and does not touch the working tree when some 
> of the hunks do not apply. This option makes it apply the parts of the patch that are applicable, and leave 
> the rejected hunks in corresponding *.rej files.

After having a look at https://github.com/git/git/blob/master/apply.c, I think that they only check for `correct_ws_error` if they couldn't apply the patch. It doesn't impact 'normal' patching. If the patch can be applied, it will be done, and only if the apply fails, they'll check whether adding or removing WS might help. It should thus be save to be added and didn't produce any errors on my installation using SDUI-provided git.