### PR TITLE
Add support for custom modifiers to d&d and clipboard

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -51,6 +51,13 @@ const TASK_MAPPING = {
         readUI: () => negativePromptField.value,
         parse: (val) => val
     },
+    active_tags: { name: "Image Modifiers",
+        setUI: (active_tags) => {
+            refreshModifiersState(active_tags)
+        },
+        readUI: () => activeTags.map(x => x.name),
+        parse: (val) => val
+    },
     width: { name: 'Width',
         setUI: (width) => {
             const oldVal = widthField.value
@@ -266,11 +273,6 @@ function restoreTaskToUI(task, fieldsToSkip) {
 
     // restore the original tag
     promptField.value = task.reqBody.original_prompt || task.reqBody.prompt
-
-    // Restore modifiers
-    if (task.reqBody.active_tags) {
-        refreshModifiersState(task.reqBody.active_tags)
-    }
 
     // properly reset checkboxes
     if (!('use_face_correction' in task.reqBody)) {


### PR DESCRIPTION
Add support for custom modifiers to d&d and clipboard and remove now-redundant code in restoreTaskToUI.