### PR TITLE
Fix weird scrolling when using a pen

### DIFF
--- a/ui/media/js/image-editor.js
+++ b/ui/media/js/image-editor.js
@@ -372,7 +372,7 @@ class ImageEditor {
 				var y = (touch.clientY || 0) - bbox.top
 			}
 		}
-	
+		event.preventDefault()	
 		// do drawing-related stuff
 		if (type == "mousedown" || (type == "mouseenter" && event.buttons == 1)) {
 			if (this.dropper_active) {


### PR DESCRIPTION
With a pen, tipping on a browser page, waiting a short moment, and then moving the pen scrolls the page. Call event.preventDefault() to disable this default behaviour for events in the canvas area.

https://discord.com/channels/1014774730907209781/1021695193499582494/1047965838482874438