### PR TITLE
Fix for RuntimeError, missing lines.

### DIFF
--- a/ui/sd_internal/runtime.py
+++ b/ui/sd_internal/runtime.py
@@ -230,6 +230,8 @@ def load_model_ckpt_sd2():
     thread_data.model.eval()
     del sd
 
+    thread_data.model.cond_stage_model.device = torch.device(thread_data.device)
+
     if thread_data.device != "cpu" and thread_data.precision == "autocast":
         thread_data.model.half()
         thread_data.model_is_half = True
@@ -768,18 +770,15 @@ def _txt2img(opt_W, opt_H, opt_n_samples, opt_ddim_steps, opt_scale, start_code,
     #                                                  x_T=start_code)
 
     if thread_data.test_sd2:
-        from ldm.models.diffusion.ddim import DDIMSampler
-        from ldm.models.diffusion.plms import PLMSSampler
-
-        shape = [opt_C, opt_H // opt_f, opt_W // opt_f]
-
         if sampler_name == 'plms':
+            from ldm.models.diffusion.plms import PLMSSampler
             sampler = PLMSSampler(thread_data.model)
         elif sampler_name == 'ddim':
+            from ldm.models.diffusion.ddim import DDIMSampler
             sampler = DDIMSampler(thread_data.model)
-
             sampler.make_schedule(ddim_num_steps=opt_ddim_steps, ddim_eta=opt_ddim_eta, verbose=False)
 
+        shape = [opt_C, opt_H // opt_f, opt_W // opt_f]
 
         samples_ddim, intermediates = sampler.sample(
             S=opt_ddim_steps,

--- a/ui/sd_internal/runtime.py
+++ b/ui/sd_internal/runtime.py
@@ -71,8 +71,6 @@ def thread_init(device):
     thread_data.device_name = None
     thread_data.unet_bs = 1
     thread_data.precision = 'autocast'
-    thread_data.sampler_plms = None
-    thread_data.sampler_ddim = None
 
     thread_data.turbo = False
     thread_data.force_full_precision = False


### PR DESCRIPTION
Missing changes from https://github.com/cmdr2/stable-diffusion-ui/pull/561

Fix this issue
```
Traceback (most recent call last):
  File "/home/madrang/WorkSpace/StableDiffusion/sd-ui/ui/sd_internal/task_manager.py", line 305, in thread_render
    task.response = runtime.mk_img(task.request, task.buffer_queue, task.temp_images, step_callback)
  File "/home/madrang/WorkSpace/StableDiffusion/sd-ui/ui/sd_internal/runtime.py", line 442, in mk_img
    raise e
  File "/home/madrang/WorkSpace/StableDiffusion/sd-ui/ui/sd_internal/runtime.py", line 427, in mk_img
    return do_mk_img(req, data_queue, task_temp_images, step_callback)
  File "/home/madrang/WorkSpace/StableDiffusion/sd-ui/ui/sd_internal/runtime.py", line 590, in do_mk_img
    uc = thread_data.model.get_learned_conditioning(batch_size * [req.negative_prompt])
  File "/home/madrang/WorkSpace/StableDiffusion/sd-ui/stable-diffusion/ldm/models/diffusion/ddpm.py", line 665, in get_learned_conditioning
    c = self.cond_stage_model.encode(c)
  File "/home/madrang/WorkSpace/StableDiffusion/sd-ui/stable-diffusion/ldm/modules/encoders/modules.py", line 193, in encode
    return self(text)
  File "/home/madrang/WorkSpace/StableDiffusion/sd-ui/stable-diffusion/env/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/madrang/WorkSpace/StableDiffusion/sd-ui/stable-diffusion/ldm/modules/encoders/modules.py", line 170, in forward
    z = self.encode_with_transformer(tokens.to(self.device))
  File "/home/madrang/WorkSpace/StableDiffusion/sd-ui/stable-diffusion/ldm/modules/encoders/modules.py", line 174, in encode_with_transformer
    x = self.model.token_embedding(text)  # [batch_size, n_ctx, d_model]
  File "/home/madrang/WorkSpace/StableDiffusion/sd-ui/stable-diffusion/env/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/madrang/WorkSpace/StableDiffusion/sd-ui/stable-diffusion/env/lib/python3.8/site-packages/torch/nn/modules/sparse.py", line 158, in forward
    return F.embedding(
  File "/home/madrang/WorkSpace/StableDiffusion/sd-ui/stable-diffusion/env/lib/python3.8/site-packages/torch/nn/functional.py", line 2183, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0! (when checking argument for argument index in method wrapper__index_select)
```