### PR TITLE
Fix upscaling when a source image is set

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -388,7 +388,8 @@ function enqueueImageVariationTask(req, img, reqDiff) {
 
 function onUpscaleClick(req, img) {
     enqueueImageVariationTask(req, img, {
-        use_upscale: upscaleModelField.value
+        use_upscale: upscaleModelField.value,
+        init_image: undefined
     })
 }
 

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -387,10 +387,28 @@ function enqueueImageVariationTask(req, img, reqDiff) {
 }
 
 function onUpscaleClick(req, img) {
-    enqueueImageVariationTask(req, img, {
-        use_upscale: upscaleModelField.value,
-        init_image: undefined
-    })
+    if (IMAGE_REGEX.test(req.init_image) && IMAGE_REGEX.test(req.mask)) {
+        enqueueImageVariationTask(req, img, {
+            use_upscale: upscaleModelField.value,
+            init_image: req.init_image,
+            mask: req.mask
+        })
+    }
+    else if (IMAGE_REGEX.test(req.init_image)) {
+        enqueueImageVariationTask(req, img, {
+            use_upscale: upscaleModelField.value,
+            init_image: req.init_image,
+            mask: undefined
+        })
+    }
+    else
+    {
+        enqueueImageVariationTask(req, img, {
+            use_upscale: upscaleModelField.value,
+            init_image: undefined,
+            mask: undefined
+        })
+    }
 }
 
 function onFixFacesClick(req, img) {


### PR DESCRIPTION
If you have an image selected (img2img) then clicking Upscale on another unrelated image, the image for img2img is used and you get something very unexpected.