### PR TITLE
Fx: Highlight artist modifiers when clicked

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -238,7 +238,8 @@ function refreshTagsList() {
 function toggleCardState(modifierName, makeActive) {
     document.querySelector('#editor-modifiers').querySelectorAll('.modifier-card').forEach(card => {
         const name = card.querySelector('.modifier-card-label').innerText
-        if (trimModifiers(modifierName) == trimModifiers(name)) {
+        if (   trimModifiers(modifierName) == trimModifiers(name)
+            || trimModifiers(modifierName) == 'by ' + trimModifiers(name)) {
             if(makeActive) {
                 card.classList.add(activeCardClass)
                 card.querySelector('.modifier-card-image-overlay').innerText = '-'


### PR DESCRIPTION
Artist modifiers, with the exception of Artstation (the first one), don't have the outline when selected. All the other modifiers, above or below, seem to work as intended

https://discord.com/channels/1014774730907209781/1014774732018683927/1048343258775949322