### PR TITLE
Fix tags not being properly applied to prompt matrix

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -940,14 +940,16 @@ function getPrompts() {
     prompts = prompts.map(prompt => prompt.trim())
     prompts = prompts.filter(prompt => prompt !== '')
 
+    let promptsToMake = applyPermuteOperator(prompts)
+    promptsToMake = applySetOperator(promptsToMake)
     const newTags = activeTags.filter(tag => tag.inactive === undefined || tag.inactive === false)
     if (newTags.length > 0) {
         const promptTags = newTags.map(x => x.name).join(", ")
-        prompts = prompts.map((prompt) => `${prompt}, ${promptTags}`)
+        promptsToMake = promptsToMake.map((prompt) => `${prompt}, ${promptTags}`)
     }
 
-    let promptsToMake = applySetOperator(prompts)
     promptsToMake = applyPermuteOperator(promptsToMake)
+    promptsToMake = applySetOperator(promptsToMake)
 
     return promptsToMake
 }


### PR DESCRIPTION
There is an issue on the beta where if you use pipe ( | ) in the prompt to make a prompt matrix, the optional prompts are only applied when the last prompt in the matrix is used.

cmdr2 - Adding JeLuf's description for the commit message:
This addresses this bug https://discord.com/channels/1014774730907209781/1021695193499582494/1049121128158859285

Optional prompts == modifiers.

Prompt a|b|c
Modifiers x,y
Jobs generated:
a
a,b
a,b,c,x,y
a,c,x,y

The modifiers get appended to the prompt first, then the | symbols are evaluated.
Patrice's PR changes the order, so that the modifiers x,y are always appended:
a,x,y
a,b,x,y
a,c,x,y
a,b,c,x,y