### PR TITLE
Add events for task creation and task restoration

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -303,8 +303,8 @@ function restoreTaskToUI(task, fieldsToSkip) {
         promptStrengthContainer.style.display = 'none'
         // maskSetting.style.display = 'none'
     }
-    // plugin event - UI settings just got restored
-    document.dispatchEvent(new CustomEvent('restoreTaskToUI_End', { detail: task.reqBody }))
+    // [plugin event] UI settings just got restored
+    document.dispatchEvent(new CustomEvent('restoreTaskToUI_After', { detail: task.reqBody }))
 }
 function readUI() {
     const reqBody = {}

--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -304,7 +304,7 @@ function restoreTaskToUI(task, fieldsToSkip) {
         // maskSetting.style.display = 'none'
     }
     // plugin event - UI settings just got restored
-    document.dispatchEvent(new CustomEvent('restoreTaskToUI_End', { detail: task }))
+    document.dispatchEvent(new CustomEvent('restoreTaskToUI_End', { detail: task.reqBody }))
 }
 function readUI() {
     const reqBody = {}

--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -303,6 +303,8 @@ function restoreTaskToUI(task, fieldsToSkip) {
         promptStrengthContainer.style.display = 'none'
         // maskSetting.style.display = 'none'
     }
+    // plugin event - UI settings just got restored
+    document.dispatchEvent(new CustomEvent('restoreTaskToUI_End', { detail: task }))
 }
 function readUI() {
     const reqBody = {}

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -927,6 +927,8 @@ function createTask(task) {
         task.previewPrompt.innerHTML = '&nbsp;' // allows the results to be collapsed
     }
 
+    // [plugin event] give plugins a chance to update the task before it's enqueued (e.g. to add custom properties)
+    document.dispatchEvent(new CustomEvent('createTask_Before', { detail: task.reqBody }))
     taskQueue.unshift(task)
 }
 


### PR DESCRIPTION
Add some events to support plugin development.
- task restoration to UI
- new task queuing

Right now this will help with the localized prompt plugin (e.g. translate a non-English prompt to English and run the resulting task).