### PR TITLE
allow aarch64

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -21,7 +21,8 @@ OS_ARCH=$(uname -m)
 case "${OS_ARCH}" in
     x86_64*)    OS_ARCH="64";;
     arm64*)     OS_ARCH="arm64";;
-    *)          echo "Unknown system architecture: $OS_ARCH! This script runs only on x86_64 or arm64" && exit
+    aarch64*)   OS_ARCH="arm64";;
+    *)          echo "Unknown system architecture: $OS_ARCH! This script runs only on x86_64 or arm64/aarch64" && exit
 esac
 
 # https://mamba.readthedocs.io/en/latest/installation.html


### PR DESCRIPTION
some systems report "aarch64" on uname -m. Allow them to run this script.

Since $OS_ARCH gets set to "aarch64" on linux systems later if it was "arm64" just use that.