### PR TITLE
Fix auto-scroll setting management

### DIFF
--- a/ui/plugins/ui/Autoscroll.plugin.js
+++ b/ui/plugins/ui/Autoscroll.plugin.js
@@ -16,18 +16,12 @@
     clearAllPreviewsBtn.parentNode.insertBefore(autoScrollControl, clearAllPreviewsBtn.nextSibling)
     prettifyInputs(document);
     let autoScroll = document.querySelector("#auto_scroll")
-
-    /**
-     * the use of initSettings() in the autoscroll plugin seems to be breaking the models dropdown and the save-to-disk folder field
-     * in the settings tab. They're both blank, because they're being re-initialized. Their earlier values came from the API call,
-     * but those values aren't stored in localStorage, since they aren't user-specified.
-     * So when initSettings() is called a second time, it overwrites the values with an empty string.
-     *
-     * We could either rework how new components can register themselves to be auto-saved, without having to call initSettings() again.
-     * Or we could move the autoscroll code into the main code, and include it in the list of fields in auto-save.js
-     */
-    // SETTINGS_IDS_LIST.push("auto_scroll")
-    // initSettings()
+    
+    // save/restore the toggle state
+    autoScroll.addEventListener('click', (e) => {
+        localStorage.setItem('auto_scroll', autoScroll.checked)
+    })
+    autoScroll.checked = localStorage.getItem('auto_scroll') == "true"
 
     // observe for changes in the preview pane
     var observer = new MutationObserver(function (mutations) {


### PR DESCRIPTION
After thinking about it, the auto-save toggle is meant for the *Editor* fields listed behind the Configure button. The auto-scroll toggle is not part of the Editor, and is more akin to a system setting, although it's placed in the main UI for convenience reasons related to its nature. As such, and especially considering it's a plugin, I lean towards decoupling auto-scroll from the auto-save settings, and just storing it independently.