### PR TITLE
Reduce delay when getting out of idle/pause

### DIFF
--- a/ui/media/js/engine.js
+++ b/ui/media/js/engine.js
@@ -1107,7 +1107,7 @@
             }
             // Calling idle could result in task being added to queue.
             if (task_queue.size <= 0 && concurrent_generators.size <= 0) {
-                return idleEventPromise.then(() => asyncDelay(IDLE_COOLDOWN))
+                return asyncDelay(IDLE_COOLDOWN).then(() => idleEventPromise)
             }
         }
         if (task_queue.size < serverCapacity) {


### PR DESCRIPTION
Start the countdown to IDLE_COOLDOWN before idleEventPromise is completed (pause removed)

Faster resuming of tasks when removing pause.