### PR TITLE
CSS only initimg hover, 'use as input' button

### DIFF
--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -1068,7 +1068,19 @@ div.task-initimg > img {
 }
 div.task-fs-initimage {
     display:  none;
+#    position: absolute;
+}
+div.task-initimg:hover div.task-fs-initimage {
+    display: block;
     position: absolute;
+    z-index: 9999;
+    box-shadow: 0 0 30px #000;
+    margin-top:-64px;
+}
+div.top-right {
+    position: absolute;
+    top: 8px;
+    right: 8px;
 }
 
 button#save-system-settings-btn {

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -743,23 +743,11 @@ async function onTaskStart(task) {
 /* Hover effect for the init image in the task list */
 function createInitImageHover(taskEntry) {
     var $tooltip = $( taskEntry.querySelector('.task-fs-initimage') )
-    $( taskEntry.querySelector('div.task-initimg > img') ).on('mouseenter', function() {
-        var img = this,
-           $img = $(img),
-           offset = $img.offset();
-    
-       $tooltip
-       .css({
-           'top': offset.top,
-           'left': offset.left,
-           'z-index': 99999,
-           'display': 'block'
-       })
-       .append($img.clone().css({width:"", height:""}));
-    })
-    $tooltip.on('mouseleave', function() {
-       $tooltip.empty().addClass('hidden');
-    });
+    var img = document.createElement('img')
+    img.src = taskEntry.querySelector('div.task-initimg > img').src
+    $tooltip.append(img)
+    $tooltip.append(`<div class="top-right"><button>Use as Input</button></div>`)
+    $tooltip.find('button').on('click', (e) => { onUseAsInputClick(null,img) } )
 }
 
 function createTask(task) {


### PR DESCRIPTION
Use a CSS only mouse hover for the initimg in the task bar instead of my previous Javascript based solution (thanks [AssassinJN](https://discord.com/channels/1014774730907209781/1021695193499582494/1053313186234912768))

Add a "Use as Input" button to the initimg hover. Useful for inpainting images which would otherwise be lost.
![image](https://user-images.githubusercontent.com/5852422/208213520-f4d31406-dd7b-43c1-a411-71826064221f.png)
