### PR TITLE
Return empty list if hostname lookup fails

### DIFF
--- a/ui/server.py
+++ b/ui/server.py
@@ -314,9 +314,15 @@ def getUIPlugins():
     return plugins
 
 def getIPConfig():
-    ips = socket.gethostbyname_ex(socket.gethostname())
-    ips[2].append(ips[0])
-    return ips[2]
+    try: 
+        ips = socket.gethostbyname_ex(socket.gethostname())
+        ips[2].append(ips[0])
+        return ips[2]
+    except Exception as e:
+        print(e)
+        print(traceback.format_exc())
+        return []
+        
 
 @app.get('/get/{key:path}')
 def read_web_data(key:str=None):


### PR DESCRIPTION
When `socket.gethostbyname_ex(socket.gethostname())` fails, the exception causes the entire `/get/system_info` call to fail. Due to this, the UI will not learn about the GPU and thus only CPU rendering will be allowed.

https://discord.com/channels/1014774730907209781/1053805801153773680/1054155074127015956