### PR TITLE
Add display order toggle setting

### DIFF
--- a/ui/media/js/auto-save.js
+++ b/ui/media/js/auto-save.js
@@ -35,6 +35,7 @@ const SETTINGS_IDS_LIST = [
     "theme",
     "save_to_disk",
     "display_order_toggle",
+    "process_order_toggle",
     "diskPath",
     "sound_toggle",
     "turbo",

--- a/ui/media/js/auto-save.js
+++ b/ui/media/js/auto-save.js
@@ -34,6 +34,7 @@ const SETTINGS_IDS_LIST = [
     "modifier-card-size-slider",
     "theme",
     "save_to_disk",
+    "display_order_toggle",
     "diskPath",
     "sound_toggle",
     "turbo",

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -423,7 +423,9 @@ function getUncompletedTaskEntries() {
             }
             return imageTaskContainer
         })
-    if (!processOrder.checked) {
+    if (!processOrder.checked && !displayOrder.checked) {
+        taskEntries.reverse()
+    }else if(processOrder.checked && displayOrder.checked){
         taskEntries.reverse()
     }
     return taskEntries

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -61,6 +61,7 @@ let clearAllPreviewsBtn = document.querySelector("#clear-all-previews")
 let maskSetting = document.querySelector('#enable_mask')
 
 const processOrder = document.querySelector('#process_order_toggle')
+const displayOrder = document.querySelector('#display_order_toggle')
 
 let imagePreview = document.querySelector("#preview")
 imagePreview.addEventListener('drop', function(ev) {
@@ -876,7 +877,11 @@ function createTask(task) {
     })
 
     task.isProcessing = true
-    taskEntry = imagePreview.insertBefore(taskEntry, previewTools.nextSibling)
+    if(displayOrder.checked){
+        taskEntry = imagePreview.appendChild(taskEntry)
+    }else{
+        taskEntry = imagePreview.append(taskEntry, previewTools.nextSibling)
+    }
     htmlTaskMap.set(taskEntry, task)
 
     task.previewPrompt.innerText = task.reqBody.prompt

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -880,7 +880,7 @@ function createTask(task) {
     if(displayOrder.checked){
         taskEntry = imagePreview.appendChild(taskEntry)
     }else{
-        taskEntry = imagePreview.append(taskEntry, previewTools.nextSibling)
+        taskEntry = imagePreview.insertBefore(taskEntry, previewTools.nextSibling)
     }
     htmlTaskMap.set(taskEntry, task)
 

--- a/ui/media/js/parameters.js
+++ b/ui/media/js/parameters.js
@@ -69,6 +69,13 @@ var PARAMETERS = [
         default: false,
     },
     {
+        id: "display_order_toggle",
+        type: ParameterType.checkbox,
+        label: "Add new tasks to bottom",
+        note: "reverse the normal display order",
+        default: false,
+    },
+    {
         id: "ui_open_browser_on_start",
         type: ParameterType.checkbox,
         label: "Open browser on startup",
@@ -223,6 +230,7 @@ let testSD2Field = document.querySelector("#test_sd2")
 let useBetaChannelField = document.querySelector("#use_beta_channel")
 let uiOpenBrowserOnStartField = document.querySelector("#ui_open_browser_on_start")
 let confirmDangerousActionsField = document.querySelector("#confirm_dangerous_actions")
+let displayOrderToggleField = document.querySelector("#display_order_toggle")
 
 let saveSettingsBtn = document.querySelector('#save-system-settings-btn')
 

--- a/ui/media/js/parameters.js
+++ b/ui/media/js/parameters.js
@@ -71,8 +71,8 @@ var PARAMETERS = [
     {
         id: "display_order_toggle",
         type: ParameterType.checkbox,
-        label: "Add new tasks to bottom",
-        note: "reverse the normal display order",
+        label: "Add new tasks to bottom of display",
+        note: "does not affect processing order",
         default: false,
     },
     {


### PR DESCRIPTION
Allows for a user level setting to configure if new tasks should be added to the top or bottom of the preview panel.