### PR TITLE
Fix copy image settings to clipboard

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -235,13 +235,6 @@ const TASK_MAPPING = {
         readUI: () => useCPUField.checked,
         parse: (val) => val
     },
-    turbo: { name: 'Turbo',
-        setUI: (turbo) => {
-            turboField.checked = turbo
-        },
-        readUI: () => turboField.checked,
-        parse: (val) => Boolean(val)
-    },
 
     stream_image_progress: { name: 'Stream Image Progress',
         setUI: (stream_image_progress) => {


### PR DESCRIPTION
Fixing the copy settings to clipboard feature. Regression was caused by the processing of the legacy turbo field, which I understand to now be obsolete.