### PR TITLE
Adding image modifiers events

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -104,6 +104,7 @@ function createModifierGroup(modifierGroup, initiallyExpanded) {
                 }
 
                 refreshTagsList()
+                document.dispatchEvent(new Event('refreshImageModifiers'))
             })
         }
     })
@@ -146,6 +147,7 @@ async function loadModifiers() {
     }
 
     loadCustomModifiers()
+    document.dispatchEvent(new Event('loadImageModifiers'))
 }
 
 function refreshModifiersState(newTags) {
@@ -227,6 +229,7 @@ function refreshTagsList() {
                 activeTags.splice(idx, 1)
                 refreshTagsList()
             }
+            document.dispatchEvent(new Event('refreshImageModifiers'))
         })
     })
 


### PR DESCRIPTION
Adding events to allow plugins to listen for image modifiers loaded and refreshed events respectively.