### PR TITLE
Proper restoration of inactive image modifiers

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -59,6 +59,13 @@ const TASK_MAPPING = {
         readUI: () => activeTags.map(x => x.name),
         parse: (val) => val
     },
+    inactive_tags: { name: "Inactive Image Modifiers",
+        setUI: (inactive_tags) => {
+            refreshInactiveTags(inactive_tags)
+        },
+        readUI: () => activeTags.filter(tag => tag.inactive === true).map(x => x.name),
+        parse: (val) => val
+    },
     width: { name: 'Width',
         setUI: (width) => {
             const oldVal = widthField.value

--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -204,6 +204,26 @@ function refreshModifiersState(newTags) {
     refreshTagsList()
 }
 
+function refreshInactiveTags(inactiveTags) {
+    // update inactive tags
+    if (inactiveTags !== undefined && inactiveTags.length > 0) {
+        activeTags.forEach (tag => {
+            if (inactiveTags.find(element => element === tag.name) !== undefined) {
+                tag.inactive = true
+            }
+        })
+    }
+    
+    // update cards
+    let overlays = document.querySelector('#editor-inputs-tags-list').querySelectorAll('.modifier-card-overlay')
+    overlays.forEach (i => {
+        let modifierName = i.parentElement.getElementsByClassName('modifier-card-label')[0].getElementsByTagName("p")[0].innerText
+        if (inactiveTags.find(element => element === modifierName) !== undefined) {
+            i.parentElement.classList.add('modifier-toggle-inactive')
+        }
+    })
+}
+
 function refreshTagsList() {
     editorModifierTagsList.innerHTML = ''
 

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -940,7 +940,8 @@ function getCurrentUserRequest() {
             output_quality: parseInt(outputQualityField.value),
             metadata_output_format: document.querySelector('#metadata_output_format').value,
             original_prompt: promptField.value,
-            active_tags: (activeTags.map(x => x.name))
+            active_tags: (activeTags.map(x => x.name)),
+            inactive_tags: (activeTags.filter(tag => tag.inactive === true).map(x => x.name))
         }
     }
     if (IMAGE_REGEX.test(initImagePreview.src)) {


### PR DESCRIPTION
Inactive image modifiers (right click on image tag) are not properly restored by Use Settings and Copy/Paste settings. This PR fixes that.

![image](https://user-images.githubusercontent.com/48073125/209875353-d4bf74d7-b8df-4ed3-a854-8010cdbcb2bd.png)
