### PR TITLE
Limit the size of zoomed-in source images

### DIFF
--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -1112,6 +1112,8 @@ div.task-initimg:hover div.task-fs-initimage {
     z-index: 9999;
     box-shadow: 0 0 30px #000;
     margin-top:-64px;
+    max-width: 75vw;
+    max-height: 75vh;
 }
 div.top-right {
     position: absolute;


### PR DESCRIPTION
If the source image has a high enough resolution it won't fit on the screen when hovering over it. This simple fix limits the max size so the user always has a chance to see the full image.

![image](https://user-images.githubusercontent.com/48073125/209892469-99d64000-b366-4d25-b6f3-055202f40c2c.png)
