### PR TITLE
Restore the original prompt if provided

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -294,9 +294,12 @@ function restoreTaskToUI(task, fieldsToSkip) {
         }
     }
 
-    // restore the original tag
-    promptField.value = task.reqBody.original_prompt || task.reqBody.prompt
-
+    // restore the original prompt if provided (e.g. use settings), fallback to prompt as needed (e.g. copy/paste or d&d)
+    promptField.value = task.reqBody.original_prompt
+    if (!('original_prompt' in task.reqBody)) {
+        promptField.value = task.reqBody.prompt
+    }
+    
     // properly reset checkboxes
     if (!('use_face_correction' in task.reqBody)) {
         useFaceCorrectionField.checked = false


### PR DESCRIPTION
Restore the original prompt if provided... including if it's empty now that empty prompts are allowed if there are modifiers. As shown in the below picture, I created a modifier-only prompt, but upon restoring the task the prompt got copied back in the prompt field, which will cause a duplication of strings in the next task (prompt + image modifiers are the same and will be concatenated).

![image](https://user-images.githubusercontent.com/48073125/209897266-b60e60f8-1222-4229-bc75-8d3c7c9d1e54.png)
