### PR TITLE
Correct bug that causes image jobs to be stuck in 'pending' state

### DIFF
--- a/ui/media/js/engine.js
+++ b/ui/media/js/engine.js
@@ -841,7 +841,8 @@
         async post(timeout=-1) {
             performance.mark('make-render-request')
             if (performance.getEntriesByName('click-makeImage', 'mark').length > 0) {
-                console.log('delay between clicking and making the server request:', performance.measure('diff', 'click-makeImage', 'make-render-request').duration + ' ms')
+                performance.measure('aname','click-makeImage', 'make-render-request');
+                console.log('delay between clicking and making the server request:', performance.getEntriesByName('aname', 'measure')[0] + ' ms')
             }
             let jsonResponse = await super.post('/render', timeout)
             if (typeof jsonResponse?.task !== 'number') {


### PR DESCRIPTION
On certain Firefox versions (ESR on Debian 102.x and more), users encounter [this error, copied below and linked from Discord](https://discord.com/channels/1014774730907209781/1057403233586385026/1057406426554834965) when attempting to have SDUI create an image, making this change in your local code appears to correct the issue. 

```
TypeError: performance.measure(...) is undefined
    post http://localhost:9000/media/js/engine.js:844
    start http://localhost:9000/media/js/engine.js:886
    continueTasks http://localhost:9000/media/js/engine.js:1152
    startCheck http://localhost:9000/media/js/engine.js:1211
    setInterval handler*init http://localhost:9000/media/js/engine.js:1237
    init http://localhost:9000/:425
    async* http://localhost:9000/:435
engine.js:1129:25
    continueTasks http://localhost:9000/media/js/engine.js:1129
    continueTasks http://localhost:9000/media/js/engine.js:1196
    continueTasks http://localhost:9000/media/js/engine.js:1196
    startCheck http://localhost:9000/media/js/engine.js:1211
    (Async: setInterval handler)
    init http://localhost:9000/media/js/engine.js:1237
    init http://localhost:9000/:425
    <anonymous> http://localhost:9000/:435
```