### PR TITLE
Enforce an autosave directory

### DIFF
--- a/ui/easydiffusion/app.py
+++ b/ui/easydiffusion/app.py
@@ -37,7 +37,7 @@ CORE_UI_PLUGINS_DIR = os.path.abspath(os.path.join(SD_UI_DIR, 'plugins', 'ui'))
 UI_PLUGINS_SOURCES = ((CORE_UI_PLUGINS_DIR, 'core'), (USER_UI_PLUGINS_DIR, 'user'))
 
 OUTPUT_DIRNAME = "Stable Diffusion UI" # in the user's home folder
-PRESERVE_CONFIG_VARS = ['FORCE_SAVE_PATH', 'FORCE_FULL_PRECISION']
+PRESERVE_CONFIG_VARS = ['FORCE_FULL_PRECISION']
 TASK_TTL = 15 * 60 # Discard last session's task timeout
 APP_CONFIG_DEFAULTS = {
     # auto: selects the cuda device with the most free memory, cuda: use the currently active cuda device.

--- a/ui/easydiffusion/server.py
+++ b/ui/easydiffusion/server.py
@@ -128,13 +128,13 @@ def read_web_data_internal(key:str=None):
     elif key == 'system_info':
         config = app.getConfig()
 
-        output_dir = os.path.join(os.path.expanduser("~"), app.OUTPUT_DIRNAME) if os.getenv('FORCE_SAVE_PATH') is None else os.getenv('FORCE_SAVE_PATH')
+        output_dir = config.get('force_save_path', os.path.join(os.path.expanduser("~"), app.OUTPUT_DIRNAME))
 
         system_info = {
             'devices': task_manager.get_devices(),
             'hosts': app.getIPConfig(),
             'default_output_dir': output_dir,
-            'enforce_output_dir': (os.getenv('FORCE_SAVE_PATH') is not None),
+            'enforce_output_dir': ('force_save_path' in config),
         }
         system_info['devices']['config'] = config.get('render_devices', "auto")
         return JSONResponse(system_info, headers=NOCACHE_HEADERS)
@@ -165,8 +165,9 @@ def render_internal(req: dict):
         task_data: TaskData = TaskData.parse_obj(req)
 
         # Overwrite user specified save path
-        if os.getenv('FORCE_SAVE_PATH') is not None:
-           task_data.save_to_disk_path = os.getenv('FORCE_SAVE_PATH')
+        config=app.getConfig
+        if 'force_save_path' in config:
+            task_data.save_to_disk_path = config['force_save_path']
 
         render_req.init_image_mask = req.get('mask') # hack: will rename this in the HTTP API in a future revision
 

--- a/ui/media/js/parameters.js
+++ b/ui/media/js/parameters.js
@@ -329,9 +329,9 @@ autoPickGPUsField.addEventListener('click', function() {
     gpuSettingEntry.style.display = (this.checked ? 'none' : '')
 })
 
-async function setDiskPath(defaultDiskPath) {
+async function setDiskPath(defaultDiskPath, force=false) {
     var diskPath = getSetting("diskPath")
-    if (diskPath == '' || diskPath == undefined || diskPath == "undefined") {
+    if (force || diskPath == '' || diskPath == undefined || diskPath == "undefined") {
         setSetting("diskPath", defaultDiskPath)
     }
 }
@@ -407,7 +407,13 @@ async function getSystemInfo() {
 
         setDeviceInfo(devices)
         setHostInfo(res['hosts'])
-        setDiskPath(res['default_output_dir'])
+        let force = false
+        if (res['enforce_output_dir'] !== undefined) {
+            force = res['enforce_output_dir']
+            saveToDiskField.disabled = force
+            diskPathField.disabled = force
+        }
+        setDiskPath(res['default_output_dir'], force)
     } catch (e) {
         console.log('error fetching devices', e)
     }


### PR DESCRIPTION
Add a config.bat/sh setting `FORCE_SAVE_PATH` that can be used by server admins to restrict auto save to a specific directory. Also useful for users who use different end devices and want to centrally configure the auto save option.
If `FORCE_SAVE_PATH` is set, the auto save options in the UI are disabled.

Fixes #597 
Fixes https://discord.com/channels/1014774730907209781/1052691036981428255

