### PR TITLE
return taskEntry.id on createTask

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -906,7 +906,7 @@ function createTask(task) {
     if (task.previewPrompt.innerText.trim() === '') {
         task.previewPrompt.innerHTML = '&nbsp;' // allows the results to be collapsed
     }
-
+    return taskEntry.id
 }
 
 function getCurrentUserRequest() {


### PR DESCRIPTION
I would like to have createTask return the taskEntry.id in order to allow for watchers or callbacks to be able to reference tasks by id more easily.