### PR TITLE
Fix parsing of text file tasks

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -451,7 +451,7 @@ async function parseContent(text) {
     }
     // Normal txt file.
     const task = parseTaskFromText(text)
-    if (task) {
+    if (text.toLowerCase().match('seed:') && task) { // only parse valid task content
         restoreTaskToUI(task)
         return true
     } else {


### PR DESCRIPTION
parseContent(text) doesn't check the text content being passed actually described a task, which causes some corner case scenarios to break (image task settings are incorrectly cleared because an empty image task is created).