### PR TITLE
Fix image editor display

### DIFF
--- a/ui/media/css/image-editor.css
+++ b/ui/media/css/image-editor.css
@@ -2,12 +2,12 @@
 	padding-left: 32px;
 	text-align: left;
 	padding-bottom: 20px;
+	max-width: min-content;
 }
 
 .editor-options-container {
 	display: flex;
 	row-gap: 10px;
-	max-width: 210px;
 }
 
 .editor-options-container > * {


### PR DESCRIPTION
Fix for the cut off controls.

Before:
![image](https://user-images.githubusercontent.com/48073125/211370228-6620e288-3bf1-4261-88ee-f8bb4a4d8f3f.png)

After:
![image](https://user-images.githubusercontent.com/48073125/211370217-07452cb5-0c89-4246-a05d-7df5cde94625.png)
