### PR TITLE
Another fix for high res images

### DIFF
--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -254,6 +254,7 @@ img {
 div.img-preview img {
     width:100%;
     height: 100%;
+    max-height: 70vh;
 }
 .line-separator {
     background: var(--background-color3);


### PR DESCRIPTION
This time to address the height.

Before:
![image](https://user-images.githubusercontent.com/48073125/211953977-dc1c544f-427f-4e60-9991-021fce61741a.png)

After:
![image](https://user-images.githubusercontent.com/48073125/211953988-0ddf7f35-44f0-4360-9cde-20e6956ffde0.png)
