### PR TITLE
Fix restoration of models with subfolders

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -363,14 +363,15 @@ function readUI() {
 }
 function getModelPath(filename, extensions)
 {
-    if (filename.includes('/models/stable-diffusion/') || filename.includes('\\models\\stable-diffusion\\')) {
-        let pathIdx = filename.lastIndexOf('/') // Linux, Mac paths
-        if (pathIdx < 0) {
-            pathIdx = filename.lastIndexOf('\\') // Windows paths.
-        }
-        if (pathIdx >= 0) {
-            filename = filename.slice(pathIdx + 1)
-        }
+    let pathIdx
+    if (filename.includes('/models/stable-diffusion/')) {
+        pathIdx = filename.indexOf('/models/stable-diffusion/') + 25 // Linux, Mac paths
+    }
+    else if (filename.includes('\\models\\stable-diffusion\\')) {
+        pathIdx = filename.indexOf('\\models\\stable-diffusion\\') + 25 // Linux, Mac paths
+    }
+    if (pathIdx >= 0) {
+        filename = filename.slice(pathIdx)
     }
     extensions.forEach(ext => {
         if (filename.endsWith(ext)) {

--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -363,12 +363,14 @@ function readUI() {
 }
 function getModelPath(filename, extensions)
 {
-    let pathIdx = filename.lastIndexOf('/') // Linux, Mac paths
-    if (pathIdx < 0) {
-        pathIdx = filename.lastIndexOf('\\') // Windows paths.
-    }
-    if (pathIdx >= 0) {
-        filename = filename.slice(pathIdx + 1)
+    if (filename.includes('/models/stable-diffusion/')) {
+        let pathIdx = filename.lastIndexOf('/') // Linux, Mac paths
+        if (pathIdx < 0) {
+            pathIdx = filename.lastIndexOf('\\') // Windows paths.
+        }
+        if (pathIdx >= 0) {
+            filename = filename.slice(pathIdx + 1)
+        }
     }
     extensions.forEach(ext => {
         if (filename.endsWith(ext)) {

--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -363,7 +363,7 @@ function readUI() {
 }
 function getModelPath(filename, extensions)
 {
-    if (filename.includes('/models/stable-diffusion/')) {
+    if (filename.includes('/models/stable-diffusion/') || filename.includes('\\models\\stable-diffusion\\')) {
         let pathIdx = filename.lastIndexOf('/') // Linux, Mac paths
         if (pathIdx < 0) {
             pathIdx = filename.lastIndexOf('\\') // Windows paths.


### PR DESCRIPTION
In dnd.js, when models are restored in the UI, there is code that strips the path from the model file name. Now that we allow models to be hosted in subfolders, this code break the task restoration (e.g. use settings, D&D, copy/paste) because "/my models/model.ckpt" becomes "model.ckpt", which won't be found.

The fix here essentially looks for the presence of '/models/stable-diffusion/', which we do know would exist in early txt files to decide whether to strip the path.

https://discord.com/channels/1014774730907209781/1014780368890630164/1063911477796417557