### PR TITLE
Group image containers (DOM tweak)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -281,8 +281,10 @@
                 and selecting the desired modifiers.<br/><br/>
                 Click "Image Settings" for additional settings like seed, image size, number of images to generate etc.<br/><br/>Enjoy! :)
             </div>
-            <div id="preview-tools">
-                <button id="clear-all-previews" class="secondaryButton"><i class="fa-solid fa-trash-can"></i> Clear All</button>
+            <div id="preview-content">
+                <div id="preview-tools">
+                    <button id="clear-all-previews" class="secondaryButton"><i class="fa-solid fa-trash-can"></i> Clear All</button>
+                </div>
             </div>
         </div>
         </div>

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -66,6 +66,7 @@ let maskSetting = document.querySelector('#enable_mask')
 const processOrder = document.querySelector('#process_order_toggle')
 
 let imagePreview = document.querySelector("#preview")
+let imagePreviewContent = document.querySelector("#preview-content")
 imagePreview.addEventListener('drop', function(ev) {
     const data = ev.dataTransfer?.getData("text/plain");
     if (!data) {
@@ -902,7 +903,7 @@ function createTask(task) {
     })
 
     task.isProcessing = true
-    taskEntry = imagePreview.insertBefore(taskEntry, previewTools.nextSibling)
+    taskEntry = imagePreviewContent.insertBefore(taskEntry, previewTools.nextSibling)
     htmlTaskMap.set(taskEntry, task)
 
     task.previewPrompt.innerText = task.reqBody.prompt


### PR DESCRIPTION
Move image containers to their own DIV container to create a clear delineation in the DOM. Purely DOM structural adjustment meant to make a sticky footer possible in the preview pane (for plugins).

HTML generated before:
![image](https://user-images.githubusercontent.com/48073125/212624290-2468e60c-73ef-4575-a7ce-5da5749c0cc9.png)

HTML generated after:
![image](https://user-images.githubusercontent.com/48073125/212624250-0eeb625e-f502-4790-bfdd-382869d334da.png)
