### PR TITLE
Support multiple GFPGAN models

### DIFF
--- a/ui/easydiffusion/model_manager.py
+++ b/ui/easydiffusion/model_manager.py
@@ -222,6 +222,7 @@ def getModels():
     listModels(model_type='stable-diffusion')
     listModels(model_type='vae')
     listModels(model_type='hypernetwork')
+    listModels(model_type='gfpgan')
 
     if models_scanned > 0: log.info(f'[green]Scanned {models_scanned} models. Nothing infected[/]')
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -232,7 +232,7 @@
                     <div><ul>
                     <li><b class="settings-subheader">Render Settings</b></li>
                     <li class="pl-5"><input id="stream_image_progress" name="stream_image_progress" type="checkbox"> <label for="stream_image_progress">Show a live preview <small>(uses more VRAM, slower images)</small></label></li>
-                    <li class="pl-5"><input id="use_face_correction" name="use_face_correction" type="checkbox"> <label for="use_face_correction">Fix incorrect faces and eyes <small>(uses GFPGAN)</small></label></li>
+                    <li class="pl-5"><input id="use_face_correction" name="use_face_correction" type="checkbox"> <label for="use_face_correction">Fix incorrect faces and eyes <small><select id="gfpgan_model" name="gfpgan_model"></select></small></label></li>
                     <li class="pl-5">
                         <input id="use_upscale" name="use_upscale" type="checkbox"> <label for="use_upscale">Scale up by</label> 
                         <select id="upscale_amount" name="upscale_amount">

--- a/ui/media/js/auto-save.js
+++ b/ui/media/js/auto-save.js
@@ -27,6 +27,7 @@ const SETTINGS_IDS_LIST = [
     "negative_prompt",
     "stream_image_progress",
     "use_face_correction",
+    "gfpgan_model",
     "use_upscale",
     "upscale_amount",
     "show_only_filtered_image",

--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -154,10 +154,21 @@ const TASK_MAPPING = {
     
     use_face_correction: { name: 'Use Face Correction',
         setUI: (use_face_correction) => {
-            useFaceCorrectionField.checked = parseBoolean(use_face_correction)
+            const oldVal = gfpganModelField.value
+            gfpganModelField.value = getModelPath(use_face_correction, ['.pth'])
+            if (gfpganModelField.value) { // Is a valid value for the field.
+                useFaceCorrectionField.checked = true
+                gfpganModelField.disabled = false
+            } else { // Not a valid value, restore the old value and disable the filter.
+                gfpganModelField.disabled = true
+                gfpganModelField.value = oldVal
+                useFaceCorrectionField.checked = false
+            }
+
+            //useFaceCorrectionField.checked = parseBoolean(use_face_correction)
         },
-        readUI: () => useFaceCorrectionField.checked,
-        parse: (val) => parseBoolean(val)
+        readUI: () => (useFaceCorrectionField.checked ? gfpganModelField.value : undefined),
+        parse: (val) => val
     },
     use_upscale: { name: 'Use Upscaling',
         setUI: (use_upscale) => {
@@ -324,6 +335,7 @@ function restoreTaskToUI(task, fieldsToSkip) {
     // properly reset checkboxes
     if (!('use_face_correction' in task.reqBody)) {
         useFaceCorrectionField.checked = false
+        gfpganModelField.disabled = true
     }
     if (!('use_upscale' in task.reqBody)) {
         useUpscalingField.checked = false

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -33,6 +33,7 @@ let promptStrengthField = document.querySelector('#prompt_strength')
 let samplerField = document.querySelector('#sampler_name')
 let samplerSelectionContainer = document.querySelector("#samplerSelection")
 let useFaceCorrectionField = document.querySelector("#use_face_correction")
+let gfpganModelField = document.querySelector("#gfpgan_model")
 let useUpscalingField = document.querySelector("#use_upscale")
 let upscaleModelField = document.querySelector("#upscale_model")
 let upscaleAmountField = document.querySelector("#upscale_amount")
@@ -412,7 +413,7 @@ function onUpscaleClick(req, img) {
 
 function onFixFacesClick(req, img) {
     enqueueImageVariationTask(req, img, {
-        use_face_correction: 'GFPGANv1.3'
+        use_face_correction: gfpganModelField.value
     })
 }
 
@@ -966,7 +967,7 @@ function getCurrentUserRequest() {
         newTask.reqBody.save_to_disk_path = diskPathField.value.trim()
     }
     if (useFaceCorrectionField.checked) {
-        newTask.reqBody.use_face_correction = 'GFPGANv1.3'
+        newTask.reqBody.use_face_correction = gfpganModelField.value
     }
     if (useUpscalingField.checked) {
         newTask.reqBody.use_upscale = upscaleModelField.value
@@ -1165,6 +1166,11 @@ function onDimensionChange() {
 
 diskPathField.disabled = !saveToDiskField.checked
 
+gfpganModelField.disabled = !useFaceCorrectionField.checked
+useFaceCorrectionField.addEventListener('change', function(e) {
+    gfpganModelField.disabled = !this.checked
+})
+
 upscaleModelField.disabled = !useUpscalingField.checked
 upscaleAmountField.disabled = !useUpscalingField.checked
 useUpscalingField.addEventListener('change', function(e) {
@@ -1284,9 +1290,11 @@ async function getModels() {
         const sd_model_setting_key = "stable_diffusion_model"
         const vae_model_setting_key = "vae_model"
         const hypernetwork_model_key = "hypernetwork_model"
+        const gfpgan_model_key = "gfpgan_model"
         const selectedSDModel = SETTINGS[sd_model_setting_key].value
         const selectedVaeModel = SETTINGS[vae_model_setting_key].value
         const selectedHypernetworkModel = SETTINGS[hypernetwork_model_key].value
+        const selectedGfpganModel = SETTINGS[gfpgan_model_key].value
 
         const models = await SD.getModels()
         const modelsOptions = models['options']
@@ -1302,6 +1310,7 @@ async function getModels() {
         const stableDiffusionOptions = modelsOptions['stable-diffusion']
         const vaeOptions = modelsOptions['vae']
         const hypernetworkOptions = modelsOptions['hypernetwork']
+        const gfpganOptions = modelsOptions['gfpgan']
 
         vaeOptions.unshift('') // add a None option
         hypernetworkOptions.unshift('') // add a None option
@@ -1329,6 +1338,8 @@ async function getModels() {
         stableDiffusionOptions.forEach(createModelOptions(stableDiffusionModelField, selectedSDModel))
         vaeOptions.forEach(createModelOptions(vaeModelField, selectedVaeModel))
         hypernetworkOptions.forEach(createModelOptions(hypernetworkModelField, selectedHypernetworkModel))
+        gfpganOptions.forEach(createModelOptions(gfpganModelField,selectedGfpganModel))
+
 
         stableDiffusionModelField.dispatchEvent(new Event('change'))
         vaeModelField.dispatchEvent(new Event('change'))


### PR DESCRIPTION
Add scanning for models and a dropdown to choose different models from.
![image](https://user-images.githubusercontent.com/5852422/213545562-2847616c-f58e-4075-a72e-e676d2f5ed43.png)

In some situations, the 1.3 version produces better results, in others, I like the 1.4 version more. I think supporting both makes sense.

This PR might conflict with the changes in #786

Fixes #265 