### PR TITLE
Fix the tooltip display over image modifier cards

### DIFF
--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -876,18 +876,19 @@ input::file-selector-button {
 
 /* SIMPLE TOOTIP */
 .simple-tooltip {
-	border-radius: 3px;
-	font-weight: bold;
-	font-size: 12px;
+    border-radius: 3px;
+    font-weight: bold;
+    font-size: 12px;
     background-color: var(--background-color3);
 
     visibility: hidden;
-	opacity: 0;
-	position: absolute;
-	width: max-content;
-	max-width: 300px;
-	padding: 8px 12px;
-	transition: 0.3s all;
+    opacity: 0;
+    position: absolute;
+    width: max-content;
+    max-width: 300px;
+    padding: 8px 12px;
+    transition: 0.3s all;
+    z-index: 1000;
 
     pointer-events: none;
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/48073125/214258072-b52654e9-7748-49d7-a0da-a51cfdae84bb.png)

After:
![image](https://user-images.githubusercontent.com/48073125/214258122-c94972de-bbea-4a34-a12e-aa21fea75bdc.png)

Also opportunistically fixed the indentation of the .simple-tooltip class declaration.