### PR TITLE
Embed metadata

### DIFF
--- a/ui/easydiffusion/utils/save_utils.py
+++ b/ui/easydiffusion/utils/save_utils.py
@@ -36,13 +36,15 @@ def save_images_to_disk(images: list, filtered_images: list, req: GenerateImageR
 
     if task_data.show_only_filtered_image or filtered_images is images:
         save_images(filtered_images, save_dir_path, file_name=make_filename, output_format=task_data.output_format, output_quality=task_data.output_quality)
-        save_dicts(metadata_entries, save_dir_path, file_name=make_filename, output_format=task_data.metadata_output_format)
+        if task_data.metadata_output_format.lower() in ['json', 'txt', 'embed']:
+            save_dicts(metadata_entries, save_dir_path, file_name=make_filename, output_format=task_data.metadata_output_format, file_format=task_data.output_format)
     else:
         make_filter_filename = make_filename_callback(req, now=now, suffix='filtered')
 
         save_images(images, save_dir_path, file_name=make_filename, output_format=task_data.output_format, output_quality=task_data.output_quality)
         save_images(filtered_images, save_dir_path, file_name=make_filter_filename, output_format=task_data.output_format, output_quality=task_data.output_quality)
-        save_dicts(metadata_entries, save_dir_path, file_name=make_filter_filename, output_format=task_data.metadata_output_format)
+        if task_data.metadata_output_format.lower() in ['json', 'txt', 'embed']:
+            save_dicts(metadata_entries, save_dir_path, file_name=make_filter_filename, output_format=task_data.metadata_output_format, file_format=task_data.output_format)
 
 def get_metadata_entries_for_request(req: GenerateImageRequest, task_data: TaskData):
     metadata = get_printable_request(req)

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -941,7 +941,7 @@ function getCurrentUserRequest() {
             show_only_filtered_image: showOnlyFilteredImageField.checked,
             output_format: outputFormatField.value,
             output_quality: parseInt(outputQualityField.value),
-            metadata_output_format: document.querySelector('#metadata_output_format').value,
+            metadata_output_format: metadataOutputFormatField.value,
             original_prompt: promptField.value,
             active_tags: (activeTags.map(x => x.name)),
             inactive_tags: (activeTags.filter(tag => tag.inactive === true).map(x => x.name))

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1164,6 +1164,7 @@ function onDimensionChange() {
 }
 
 diskPathField.disabled = !saveToDiskField.checked
+metadataOutputFormatField.disabled = !saveToDiskField.checked
 
 upscaleModelField.disabled = !useUpscalingField.checked
 upscaleAmountField.disabled = !useUpscalingField.checked

--- a/ui/media/js/parameters.js
+++ b/ui/media/js/parameters.js
@@ -58,8 +58,12 @@ var PARAMETERS = [
         type: ParameterType.select,
         label: "Metadata format",
         note: "will be saved to disk in this format",
-        default: "txt",
+        default: "none",
         options: [
+            {
+                value: "none",
+                label: "none"
+            },
             {
                 value: "txt",
                 label: "txt"
@@ -67,6 +71,10 @@ var PARAMETERS = [
             {
                 value: "json",
                 label: "json"
+            },
+            {
+                value: "embed",
+                label: "embed"
             }
         ],
     },
@@ -226,6 +234,7 @@ let autoPickGPUsField = document.querySelector('#auto_pick_gpus')
 let useGPUsField = document.querySelector('#use_gpus')
 let saveToDiskField = document.querySelector('#save_to_disk')
 let diskPathField = document.querySelector('#diskPath')
+let metadataOutputFormatField = document.querySelector('#metadata_output_format')
 let listenToNetworkField = document.querySelector("#listen_to_network")
 let listenPortField = document.querySelector("#listen_port")
 let useBetaChannelField = document.querySelector("#use_beta_channel")
@@ -279,6 +288,7 @@ async function getAppConfig() {
 
 saveToDiskField.addEventListener('change', function(e) {
     diskPathField.disabled = !this.checked
+    metadataOutputFormatField.disabled = !this.checked
 })
 
 function getCurrentRenderDeviceSelection() {


### PR DESCRIPTION
*** Please merge https://github.com/easydiffusion/sdkit/pull/9 before merging this one. ***

This is the ED client part of metadata embedding. It adds 'embed' and 'none' options to the metadata setting and makes none the default (if never set before) because (1) it feels weird to create metadata files by default and (2) embedding by default could cause be problematic if users don't realize it's happening.

Also fixes the disabling of the dropdown in the settings when Save images to disk is toggled off.