### PR TITLE
Fix aarch64 (arm64) verification

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -21,6 +21,7 @@ OS_ARCH=$(uname -m)
 case "${OS_ARCH}" in
     x86_64*)    OS_ARCH="64";;
     arm64*)     OS_ARCH="arm64";;
+    aarch64*)     OS_ARCH="arm64";;
     *)          echo "Unknown system architecture: $OS_ARCH! This script runs only on x86_64 or arm64" && exit
 esac
 


### PR DESCRIPTION
I tried to run the start.sh script in Asahi Linux on a Mac mini with an Apple CPU and I could see that the first failure is verification of CPU architecture.

The script basically says that my architecture is aarch64 and not arm64, to fix this I added a condition that accepts aarch64 because I understand that aarch64 and arm64 are the same thing.
