### PR TITLE
Fix 'Pause All' function

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -673,6 +673,9 @@ function onTaskCompleted(task, reqBody, instance, outputContainer, stepUpdate) {
         return
     }
 
+    if (pauseClient) { 
+        resumeBtn.click() 
+    }
     renderButtons.style.display = 'none'
     renameMakeImageButton()
 


### PR DESCRIPTION
If 'pause all' is clicked during the last scheduled job, the 'resume all' button gets hidden when the jobs terminates, making it impossible to unpause the engine.
https://discord.com/channels/1014774730907209781/1014780368890630164/1071584183417323602