### PR TITLE
Sort models alphabetically

### DIFF
--- a/ui/easydiffusion/model_manager.py
+++ b/ui/easydiffusion/model_manager.py
@@ -200,7 +200,7 @@ def getModels():
                 scan=scan_directory(entry.path, suffixes, directoriesFirst=False)
 
                 if len(scan) != 0:
-                    tree.append( (entry.name, scan ) )                       
+                    tree.append( (entry.name, scan ) )
         return tree
 
     def listModels(model_type):

--- a/ui/easydiffusion/model_manager.py
+++ b/ui/easydiffusion/model_manager.py
@@ -179,10 +179,10 @@ def getModels():
         "Raised when picklescan reports a problem with a model"
         pass
 
-    def scan_directory(directory, suffixes):
+    def scan_directory(directory, suffixes, directoriesFirst:bool=True):
         nonlocal models_scanned
         tree = []
-        for entry in sorted(os.scandir(directory), key = lambda entry: (entry.is_file(), entry.name.lower())):
+        for entry in sorted(os.scandir(directory), key = lambda entry: (entry.is_file() == directoriesFirst, entry.name.lower())):
             if entry.is_file():
                 matching_suffix = list(filter(lambda s: entry.name.endswith(s), suffixes))
                 if len(matching_suffix) == 0: continue
@@ -197,9 +197,10 @@ def getModels():
                 known_models[entry.path] = mtime
                 tree.append(entry.name[:-len(matching_suffix)])
             elif entry.is_dir():
-                scan=scan_directory(entry.path, suffixes) 
+                scan=scan_directory(entry.path, suffixes, directoriesFirst=False)
+
                 if len(scan) != 0:
-                    tree.append( (entry.name, scan ) )
+                    tree.append( (entry.name, scan ) )                       
         return tree
 
     def listModels(model_type):

--- a/ui/easydiffusion/model_manager.py
+++ b/ui/easydiffusion/model_manager.py
@@ -182,7 +182,7 @@ def getModels():
     def scan_directory(directory, suffixes):
         nonlocal models_scanned
         tree = []
-        for entry in os.scandir(directory):
+        for entry in sorted(os.scandir(directory), key = lambda entry: (entry.is_file(), entry.name.lower())):
             if entry.is_file():
                 matching_suffix = list(filter(lambda s: entry.name.endswith(s), suffixes))
                 if len(matching_suffix) == 0: continue

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1322,9 +1322,12 @@ async function getModels() {
                     }
                     modelField.appendChild(modelOption)
                 } else {
-                    const modelGroup = document.createElement('optgroup')
-                    modelGroup.label = path + modelName[0]
-                    modelField.appendChild(modelGroup)
+                    // Since <optgroup/>s can't be nested, don't show empty groups
+                    if (modelName[1].some(child => typeof(child) == 'string')) {
+                        const modelGroup = document.createElement('optgroup')
+                        modelGroup.label = path + modelName[0]
+                        modelField.appendChild(modelGroup)
+                    }
                     modelName[1].forEach( createModelOptions(modelField, selectedModel, path + modelName[0] + "/" ) )
                 }
             }


### PR DESCRIPTION
With EasyDiffusion 2.5 models stopped being sorted alphabetically, which makes it hard to find a specific model when you have a lot of them. I'm adding back sorting, as well as making the sort case insensitive.
I also changed it so that folders appear on top. For child folders the grandchild folders appear last, to prevent the UI from looking like

* **ChildFolder**
* **ChildFolder/GrandchildFolder**
  * Model1
  * Model2

when Model2 belongs to ChildFolder and Model1 belongs GrandchildFolder.

I also updated the UI so that folders that only contain more folders will not appear in the select menus.

With sorting:
![EasyDiffusion Sorted Models](https://user-images.githubusercontent.com/8977984/217116390-d2eb90e2-3e1f-4463-a536-3ba173df8207.png)
