### PR TITLE
Restore VAE model in metadata files and remove prompt strength in txt2img generations

### DIFF
--- a/ui/easydiffusion/utils/save_utils.py
+++ b/ui/easydiffusion/utils/save_utils.py
@@ -24,6 +24,7 @@ TASK_TEXT_MAPPING = {
     'sampler_name': 'Sampler',
     'negative_prompt': 'Negative Prompt',
     'use_stable_diffusion_model': 'Stable Diffusion model',
+    'use_vae_model': 'VAE model',
     'use_hypernetwork_model': 'Hypernetwork model',
     'hypernetwork_strength': 'Hypernetwork Strength'
 }
@@ -71,6 +72,8 @@ def get_printable_request(req: GenerateImageRequest):
     metadata = req.dict()
     del metadata['init_image']
     del metadata['init_image_mask']
+    if (req.init_image is None):
+        del metadata['prompt_strength']
     return metadata
 
 def make_filename_callback(req: GenerateImageRequest, suffix=None, now=None):

--- a/ui/easydiffusion/utils/save_utils.py
+++ b/ui/easydiffusion/utils/save_utils.py
@@ -56,6 +56,8 @@ def get_metadata_entries_for_request(req: GenerateImageRequest, task_data: TaskD
     })
     if metadata['use_upscale'] is not None:
         metadata['upscale_amount'] = task_data.upscale_amount
+    if (task_data.use_hypernetwork_model is None):
+        del metadata['hypernetwork_strength']
 
     # if text, format it in the text format expected by the UI
     is_txt_format = (task_data.metadata_output_format.lower() == 'txt')


### PR DESCRIPTION
it appears that in EasyDiffusion 2.5 the VAE model parameter in metadata files was accidentally removed. I added the missing label so that VAE models are outputted again.
I also removed the `Prompt Strength: 0.8` parameter in metadata files if you're using txt2img, since it's misleading. And I also removed `Hypernetwork Strength: None` when the hypernetwork model is none, since it's unnecessary.