### PR TITLE
Fix the behavior of the use as input button

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -774,7 +774,10 @@ function createInitImageHover(taskEntry) {
     img.src = taskEntry.querySelector('div.task-initimg > img').src
     $tooltip.append(img)
     $tooltip.append(`<div class="top-right"><button>Use as Input</button></div>`)
-    $tooltip.find('button').on('click', (e) => { onUseAsInputClick(null,img) } )
+    $tooltip.find('button').on('click', (e) => {
+        e.stopPropagation()
+        onUseAsInputClick(null,img) 
+    })
 }
 
 let startX, startY;


### PR DESCRIPTION
Clicking the button toggles the task container behind it.

![image](https://user-images.githubusercontent.com/48073125/217409934-e65b13ee-9e50-4e1b-a936-bae684709c76.png)
