### PR TITLE
Add hook to implement custom prompt preprocessors

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1015,6 +1015,8 @@ function getPrompts(prompts) {
     promptsToMake = applyPermuteOperator(promptsToMake)
     promptsToMake = applySetOperator(promptsToMake)
 
+    PLUGINS['GET_PROMPTS_HOOK'].forEach(fn => { promptsToMake = fn(promptsToMake) })
+
     return promptsToMake
 }
 

--- a/ui/media/js/plugins.js
+++ b/ui/media/js/plugins.js
@@ -25,6 +25,7 @@ const PLUGINS = {
      * })
      */
     IMAGE_INFO_BUTTONS: [],
+    GET_PROMPTS_HOOK: [],
     MODIFIERS_LOAD: [],
     TASK_CREATE: [],
     OUTPUTS_FORMATS: new ServiceContainer(


### PR DESCRIPTION
https://discord.com/channels/1014774730907209781/1014774732018683928/1072787224850092083

Adds a hook that can be used to extend the client side prompt preprocessor, before the prompt is passed on to the tasks.