### PR TITLE
Changes to make things work on MacOS/x64

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -58,7 +58,7 @@ if [ "$PACKAGES_TO_INSTALL" != "" ]; then
         echo "Downloading micromamba from $MICROMAMBA_DOWNLOAD_URL to $MAMBA_ROOT_PREFIX/micromamba"
 
         mkdir -p "$MAMBA_ROOT_PREFIX"
-        curl -L "$MICROMAMBA_DOWNLOAD_URL" | tar -xvj bin/micromamba -O > "$MAMBA_ROOT_PREFIX/micromamba"
+        curl -L "$MICROMAMBA_DOWNLOAD_URL" | tar -xvj -O bin/micromamba > "$MAMBA_ROOT_PREFIX/micromamba"
 
         if [ "$?" != "0" ]; then
             echo

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -28,5 +28,12 @@ EOF
 
 }
 
+filesize() {
+    case "$(uname -s)" in
+        Linux*)     stat -c "%s" $1;;
+        Darwin*)    stat -f "%z" $1;;
+        *)          echo "Unknown OS: $OS_NAME! This script runs only on Linux or Mac" && exit
+    esac
+}
 
 

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -137,7 +137,7 @@ else
 fi
 
 if [ -f "../models/stable-diffusion/sd-v1-4.ckpt" ]; then
-    model_size=`find "../models/stable-diffusion/sd-v1-4.ckpt" -printf "%s"`
+    model_size=`filesize "../models/stable-diffusion/sd-v1-4.ckpt"`
 
     if [ "$model_size" -eq "4265380512" ] || [ "$model_size" -eq "7703807346" ] || [ "$model_size" -eq "7703810927" ]; then
         echo "Data files (weights) necessary for Stable Diffusion were already downloaded"
@@ -153,7 +153,7 @@ if [ ! -f "../models/stable-diffusion/sd-v1-4.ckpt" ]; then
     curl -L -k https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt > ../models/stable-diffusion/sd-v1-4.ckpt
 
     if [ -f "../models/stable-diffusion/sd-v1-4.ckpt" ]; then
-        model_size=`find "../models/stable-diffusion/sd-v1-4.ckpt" -printf "%s"`
+        model_size=`filesize "../models/stable-diffusion/sd-v1-4.ckpt"`
         if [ ! "$model_size" == "4265380512" ]; then
 	    fail "The downloaded model file was invalid! Bytes downloaded: $model_size"
         fi
@@ -164,7 +164,7 @@ fi
 
 
 if [ -f "../models/gfpgan/GFPGANv1.3.pth" ]; then
-    model_size=`find "../models/gfpgan/GFPGANv1.3.pth" -printf "%s"`
+    model_size=`filesize "../models/gfpgan/GFPGANv1.3.pth"`
 
     if [ "$model_size" -eq "348632874" ]; then
         echo "Data files (weights) necessary for GFPGAN (Face Correction) were already downloaded"
@@ -180,7 +180,7 @@ if [ ! -f "../models/gfpgan/GFPGANv1.3.pth" ]; then
     curl -L -k https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.3.pth > ../models/gfpgan/GFPGANv1.3.pth
 
     if [ -f "../models/gfpgan/GFPGANv1.3.pth" ]; then
-        model_size=`find "../models/gfpgan/GFPGANv1.3.pth" -printf "%s"`
+        model_size=`filesize "../models/gfpgan/GFPGANv1.3.pth"`
         if [ ! "$model_size" -eq "348632874" ]; then
             fail "The downloaded GFPGAN model file was invalid! Bytes downloaded: $model_size"
         fi
@@ -191,7 +191,7 @@ fi
 
 
 if [ -f "../models/realesrgan/RealESRGAN_x4plus.pth" ]; then
-    model_size=`find "../models/realesrgan/RealESRGAN_x4plus.pth" -printf "%s"`
+    model_size=`filesize "../models/realesrgan/RealESRGAN_x4plus.pth"`
 
     if [ "$model_size" -eq "67040989" ]; then
         echo "Data files (weights) necessary for ESRGAN (Resolution Upscaling) x4plus were already downloaded"
@@ -207,7 +207,7 @@ if [ ! -f "../models/realesrgan/RealESRGAN_x4plus.pth" ]; then
     curl -L -k https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth > ../models/realesrgan/RealESRGAN_x4plus.pth
 
     if [ -f "../models/realesrgan/RealESRGAN_x4plus.pth" ]; then
-        model_size=`find "../models/realesrgan/RealESRGAN_x4plus.pth" -printf "%s"`
+        model_size=`filesize "../models/realesrgan/RealESRGAN_x4plus.pth"`
         if [ ! "$model_size" -eq "67040989" ]; then
             fail "The downloaded ESRGAN x4plus model file was invalid! Bytes downloaded: $model_size"
         fi
@@ -218,7 +218,7 @@ fi
 
 
 if [ -f "../models/realesrgan/RealESRGAN_x4plus_anime_6B.pth" ]; then
-    model_size=`find "../models/realesrgan/RealESRGAN_x4plus_anime_6B.pth" -printf "%s"`
+    model_size=`filesize "../models/realesrgan/RealESRGAN_x4plus_anime_6B.pth"`
 
     if [ "$model_size" -eq "17938799" ]; then
         echo "Data files (weights) necessary for ESRGAN (Resolution Upscaling) x4plus_anime were already downloaded"
@@ -234,7 +234,7 @@ if [ ! -f "../models/realesrgan/RealESRGAN_x4plus_anime_6B.pth" ]; then
     curl -L -k https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth > ../models/realesrgan/RealESRGAN_x4plus_anime_6B.pth
 
     if [ -f "../models/realesrgan/RealESRGAN_x4plus_anime_6B.pth" ]; then
-        model_size=`find "../models/realesrgan/RealESRGAN_x4plus_anime_6B.pth" -printf "%s"`
+        model_size=`filesize "../models/realesrgan/RealESRGAN_x4plus_anime_6B.pth"`
         if [ ! "$model_size" -eq "17938799" ]; then
             fail "The downloaded ESRGAN x4plus_anime model file was invalid! Bytes downloaded: $model_size"
         fi
@@ -245,7 +245,7 @@ fi
 
 
 if [ -f "../models/vae/vae-ft-mse-840000-ema-pruned.ckpt" ]; then
-    model_size=`find ../models/vae/vae-ft-mse-840000-ema-pruned.ckpt -printf "%s"`
+    model_size=`filesize "../models/vae/vae-ft-mse-840000-ema-pruned.ckpt"`
 
     if [ "$model_size" -eq "334695179" ]; then
         echo "Data files (weights) necessary for the default VAE (sd-vae-ft-mse-original) were already downloaded"
@@ -261,7 +261,7 @@ if [ ! -f "../models/vae/vae-ft-mse-840000-ema-pruned.ckpt" ]; then
     curl -L -k https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.ckpt > ../models/vae/vae-ft-mse-840000-ema-pruned.ckpt
 
     if [ -f "../models/vae/vae-ft-mse-840000-ema-pruned.ckpt" ]; then
-        model_size=`find ../models/vae/vae-ft-mse-840000-ema-pruned.ckpt -printf "%s"`
+        model_size=`filesize "../models/vae/vae-ft-mse-840000-ema-pruned.ckpt"`
         if [ ! "$model_size" -eq "334695179" ]; then
             printf "\n\nError: The downloaded default VAE (sd-vae-ft-mse-original) file was invalid! Bytes downloaded: $model_size\n\n"
             printf "\n\nError downloading the data files (weights) for the default VAE (sd-vae-ft-mse-original). Sorry about that, please try to:\n  1. Run this installer again.\n  2. If that doesn't fix it, please try the common troubleshooting steps at https://github.com/cmdr2/stable-diffusion-ui/wiki/Troubleshooting\n  3. If those steps don't help, please copy *all* the error messages in this window, and ask the community at https://discord.com/invite/u9yhsFmEkB\n  4. If that doesn't solve the problem, please file an issue at https://github.com/cmdr2/stable-diffusion-ui/issues\nThanks!\n\n"

--- a/ui/easydiffusion/app.py
+++ b/ui/easydiffusion/app.py
@@ -45,7 +45,7 @@ APP_CONFIG_DEFAULTS = {
     'update_branch': 'main',
     'ui': {
         'open_browser_on_start': True,
-    },
+    }
 }
 
 def init():
@@ -57,16 +57,21 @@ def getConfig(default_val=APP_CONFIG_DEFAULTS):
     try:
         config_json_path = os.path.join(CONFIG_DIR, 'config.json')
         if not os.path.exists(config_json_path):
-            return default_val
-        with open(config_json_path, 'r', encoding='utf-8') as f:
-            config = json.load(f)
-            if 'net' not in config:
-                config['net'] = {}
-            if os.getenv('SD_UI_BIND_PORT') is not None:
-                config['net']['listen_port'] = int(os.getenv('SD_UI_BIND_PORT'))
-            if os.getenv('SD_UI_BIND_IP') is not None:
-                config['net']['listen_to_network'] = (os.getenv('SD_UI_BIND_IP') == '0.0.0.0')
-            return config
+            config = default_val
+        else:
+            with open(config_json_path, 'r', encoding='utf-8') as f:
+                config = json.load(f)
+        if 'net' not in config:
+            config['net'] = {}
+        if os.getenv('SD_UI_BIND_PORT') is not None:
+            config['net']['listen_port'] = int(os.getenv('SD_UI_BIND_PORT'))
+        else:
+            config['net']['listen_port'] = 9000
+        if os.getenv('SD_UI_BIND_IP') is not None:
+            config['net']['listen_to_network'] = (os.getenv('SD_UI_BIND_IP') == '0.0.0.0')
+        else:
+            config['net']['listen_to_network'] = True
+        return config
     except Exception as e:
         log.warn(traceback.format_exc())
         return default_val


### PR DESCRIPTION
These changes were developed in this [discord conversation](https://discord.com/channels/1014774730907209781/1039581234948476929/1073511002873806908)

- Fix `tar` invocation: Flags need to be provided before filenames
- `find` has no `printf` function on MacOS. Use `stat` instead. Implemented as a `filesize` function
- Fix `sysctl` invocation
- Fix default handling for the network parameters (Fixes #840)