### PR TITLE
Fix the inpainter and image editor display

### DIFF
--- a/ui/media/css/image-editor.css
+++ b/ui/media/css/image-editor.css
@@ -160,6 +160,7 @@
 	padding: var(--popup-padding);
 	min-height: calc(100vh - (2 * var(--popup-margin)));
 	max-width: none;
+	min-width: fit-content;
 }
 
 .image-editor-popup h1 {


### PR DESCRIPTION
Quick fix  for the inpainter and image editor display when browser window has an horizontal scrollbar.

Before:
![image](https://user-images.githubusercontent.com/48073125/218295518-9e3bb28a-6957-459f-8927-fd6812311e1e.png)

After:
![image](https://user-images.githubusercontent.com/48073125/218295522-12e7d741-3a3b-4329-8756-8d535c36d83f.png)
