### PR TITLE
Fix reloading of tasks with no file path

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -375,6 +375,10 @@ function readUI() {
 }
 function getModelPath(filename, extensions)
 {
+    if (filename === null) {
+        return
+    }
+    
     let pathIdx
     if (filename.includes('/models/stable-diffusion/')) {
         pathIdx = filename.indexOf('/models/stable-diffusion/') + 25 // Linux, Mac paths


### PR DESCRIPTION
In some conditions tasks may be reloaded with an empty file path (e.g. no face correction). This causes the task reloading to throw an exception during the below test because filename is null.

    if (filename.includes('/models/stable-diffusion/')) {
    ...
    }
