### PR TITLE
Cleaning up event listener that's no longer needed

### DIFF
--- a/ui/plugins/ui/merge.plugin.js
+++ b/ui/plugins/ui/merge.plugin.js
@@ -334,15 +334,10 @@
     linkTabContents(tabSettingsSingle)
     linkTabContents(tabSettingsBatch)
 
-    /////////////////////// Event Listener
-    document.addEventListener('tabClick', (e) => { 
-        if (e.detail.name == 'merge') {
-	    console.log('Activate')
-            let mergeModelAField = new ModelDropdown(document.querySelector('#mergeModelA'), 'stable-diffusion')
-            let mergeModelBField = new ModelDropdown(document.querySelector('#mergeModelB'), 'stable-diffusion')
-            updateChart()
-	}
-    })
+    console.log('Activate')
+    let mergeModelAField = new ModelDropdown(document.querySelector('#mergeModelA'), 'stable-diffusion')
+    let mergeModelBField = new ModelDropdown(document.querySelector('#mergeModelB'), 'stable-diffusion')
+    updateChart()
 
     // slider
     const singleMergeRatioField = document.querySelector('#single-merge-ratio')


### PR DESCRIPTION
The event listener instantiates two objects every time the user clicks on the Merge tab. This is no longer needed after AssassinJN's CSS fixes from yesterday.