### PR TITLE
Only confirm image deletion once

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -270,6 +270,22 @@ function showImages(reqBody, res, outputContainer, livePreview) {
                 </div>
             `
             outputContainer.appendChild(imageItemElem)
+            const imageRemoveBtn = imageItemElem.querySelector('.imgPreviewItemClearBtn')
+            let parentTaskContainer = imageRemoveBtn.closest('.imageTaskContainer')
+            imageRemoveBtn.addEventListener('click', (e) => {
+                shiftOrConfirm(e, "Remove the image from the results?", () => { 
+                    imageItemElem.style.display = 'none' 
+                    let allHidden = true;
+                    let children = parentTaskContainer.querySelectorAll('.imgItem');
+                    for(let x = 0; x < children.length; x++) {
+                        let child = children[x];
+                        if(child.style.display != "none") {
+                            allHidden = false;
+                        }
+                    }
+                    if(allHidden === true) {parentTaskContainer.classList.add("displayNone")}
+                })
+            })
         }
         const imageElem = imageItemElem.querySelector('img')
         imageElem.src = imageData
@@ -279,23 +295,6 @@ function showImages(reqBody, res, outputContainer, livePreview) {
         imageElem.setAttribute('data-steps', imageInferenceSteps)
         imageElem.setAttribute('data-guidance', imageGuidanceScale)
 
-        const imageRemoveBtn = imageItemElem.querySelector('.imgPreviewItemClearBtn')
-        let parentTaskContainer = imageRemoveBtn.closest('.imageTaskContainer')
-        imageRemoveBtn.addEventListener('click', (e) => {
-            console.log(e)
-            shiftOrConfirm(e, "Remove the image from the results?", () => { 
-                imageItemElem.style.display = 'none' 
-                let allHidden = true;
-                let children = parentTaskContainer.querySelectorAll('.imgItem');
-                for(let x = 0; x < children.length; x++) {
-                    let child = children[x];
-                    if(child.style.display != "none") {
-                        allHidden = false;
-                    }
-                }
-                if(allHidden === true) {parentTaskContainer.classList.add("displayNone")}
-            })
-        })
 
         const imageInfo = imageItemElem.querySelector('.imgItemInfo')
         imageInfo.style.visibility = (livePreview ? 'hidden' : 'visible')


### PR DESCRIPTION
The previous code added an event listener per preview image (if live preview is enabled), so that multiple confirmations were required.