### PR TITLE
Remove superfluous CarriageReturn

### DIFF
--- a/ui/easydiffusion/app.py
+++ b/ui/easydiffusion/app.py
@@ -105,7 +105,7 @@ def setConfig(config):
 
         if len(config_bat) > 0:
             with open(config_bat_path, "w", encoding="utf-8") as f:
-                f.write("\r\n".join(config_bat))
+                f.write("\n".join(config_bat))
     except:
         log.error(traceback.format_exc())
 


### PR DESCRIPTION
\r\n creates CR CR LF in python, which confuses the Windows batch processor. With only \n, adding the config line for FP32 works as expected:

10:50:43.659 WARNING cuda:0 forcing full precision on this GPU, to avoid green images. GPU detected: NVIDIA GeForce GTX 1060 6GB

https://discord.com/channels/1014774730907209781/1014774732018683926/1076074641669488760