### PR TITLE
Fix filename parsing issue

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -375,7 +375,7 @@ function readUI() {
 }
 function getModelPath(filename, extensions)
 {
-    if (filename === null) {
+    if (typeof filename !== "string") {
         return
     }
     


### PR DESCRIPTION
Here is a more robust fix for task restoration in dnd.js. Task restoration will fail if the JSON contains "use_face_correction": false, which can happen under some circumstances.

The fix checks if the filename passed to getModelPath is actually a string, which covers both the previous scenario (filename === null) and this new one (filename === false).

https://discord.com/channels/1014774730907209781/1058857864954904607/1076328310138732644