### PR TITLE
Fix autoscroll behavior for the first image

### DIFF
--- a/ui/plugins/ui/Autoscroll.plugin.js
+++ b/ui/plugins/ui/Autoscroll.plugin.js
@@ -39,7 +39,10 @@
 
     function Autoscroll(target) {
         if (autoScroll.checked && target !== null) {
-            target.parentElement.parentElement.parentElement.scrollIntoView();
+            const img = target.querySelector('img')
+            img.addEventListener('load', function() {
+                img.closest('.imageTaskContainer').scrollIntoView()
+            }, { once: true })
         }
     }
 })()


### PR DESCRIPTION
When the first image is generated, the autoscroll triggers before the image is fully displayed by the browser. This causes it to not be positioned properly. The fix is to listen for the "load" event on the IMG element before triggering the scrolling event. Once the image fully loaded and rendered, the browser correctly detects the size of the viewport and renders properly.

Before:
![image](https://user-images.githubusercontent.com/48073125/219849052-621f2b74-d24f-4cb9-90c0-0838d27c06d9.png)

After:
![image](https://user-images.githubusercontent.com/48073125/219849056-d78dc949-39a5-44db-b050-fa93c71bf899.png)
