### PR TITLE
Support WEBP image formats

### DIFF
--- a/ui/easydiffusion/types.py
+++ b/ui/easydiffusion/types.py
@@ -38,7 +38,7 @@ class TaskData(BaseModel):
     use_hypernetwork_model: str = None
 
     show_only_filtered_image: bool = False
-    output_format: str = "jpeg"  # or "png"
+    output_format: str = "jpeg"  # or "png" or "webp"
     output_quality: int = 75
     metadata_output_format: str = "txt"  # or "json"
     stream_image_progress: bool = False

--- a/ui/index.html
+++ b/ui/index.html
@@ -223,9 +223,10 @@
                         <select id="output_format" name="output_format">
                             <option value="jpeg" selected>jpeg</option>
                             <option value="png">png</option>
+                            <option value="webp">webp</option>
                         </select>
                     </td></tr>
-                    <tr class="pl-5" id="output_quality_row"><td><label for="output_quality">JPEG Quality:</label></td><td>
+                    <tr class="pl-5" id="output_quality_row"><td><label for="output_quality">Image Quality:</label></td><td>
                     <input id="output_quality_slider" name="output_quality" class="editor-slider" value="75" type="range" min="10" max="95"> <input id="output_quality" name="output_quality" size="4" pattern="^[0-9\.]+$" onkeypress="preventNonNumericalInput(event)">
                     </td></tr>
                     </table></div>

--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -2,7 +2,7 @@
 
 const EXT_REGEX = /(?:\.([^.]+))?$/
 const TEXT_EXTENSIONS = ['txt', 'json']
-const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'bmp', 'tiff', 'tif', 'tga']
+const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'bmp', 'tiff', 'tif', 'tga', 'webp']
 
 function parseBoolean(stringValue) {
     if (typeof stringValue === 'boolean') {

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1125,7 +1125,7 @@ function createFileName(prompt, seed, steps, guidance, outputFormat) {
     // fileName += `${tagString}`
 
     // add the file extension
-    fileName += '.' + (outputFormat === 'png' ? 'png' : 'jpeg')
+    fileName += '.' + outputFormat
 
     return fileName
 }
@@ -1301,7 +1301,7 @@ function updateHypernetworkStrengthContainer() {
 hypernetworkModelField.addEventListener('change', updateHypernetworkStrengthContainer)
 updateHypernetworkStrengthContainer()
 
-/********************* JPEG Quality **********************/
+/********************* JPEG/WEBP Quality **********************/
 function updateOutputQuality() {
     outputQualityField.value =  0 | outputQualitySlider.value
     outputQualityField.dispatchEvent(new Event("change"))
@@ -1323,10 +1323,10 @@ outputQualityField.addEventListener('input', debounce(updateOutputQualitySlider,
 updateOutputQuality()
 
 outputFormatField.addEventListener('change', e => {
-    if (outputFormatField.value == 'jpeg') {
-        outputQualityRow.style.display='table-row'
-    } else {
+    if (outputFormatField.value === 'png') {
         outputQualityRow.style.display='none'
+    } else {
+        outputQualityRow.style.display='table-row'
     }
 })
 

--- a/ui/media/js/plugins.js
+++ b/ui/media/js/plugins.js
@@ -31,6 +31,7 @@ const PLUGINS = {
     OUTPUTS_FORMATS: new ServiceContainer(
         function png() { return (reqBody) => new SD.RenderTask(reqBody) }
         , function jpeg() { return (reqBody) => new SD.RenderTask(reqBody) }
+        , function webp() { return (reqBody) => new SD.RenderTask(reqBody) }
     ),
 }
 PLUGINS.OUTPUTS_FORMATS.register = function(...args) {


### PR DESCRIPTION
WEBP images are supported by the PIL image library used in sdkit. The format has extremely small file sizes. For example, a 768x760 image that I upscaled 2x to 1536x1536, was

* 189.9 Kb for a 50% quality .webp
* 244.8 Kb for a 50% quality .jpeg
* 637.7 Kb for a 95% quality .webp
* 890.7 Kb for a 95% quality .jpeg
* 3.1 Mb for a .png

All using the same parameters (seed, etc...), just changing the output format. .webp also works for source images in img2img.

I did also test .avif, but PIL throws `ValueError: unknown file extension: .avif`

![image](https://user-images.githubusercontent.com/8977984/219922197-8df2652d-afc0-4d9d-b915-5cbe57bebdd1.png)
