### PR TITLE
Fix the centering of sharpness brushes

### DIFF
--- a/ui/media/js/image-editor.js
+++ b/ui/media/js/image-editor.js
@@ -244,8 +244,8 @@ var IMAGE_EDITOR_SECTIONS = [
 			var sub_element = document.createElement("div")
 			sub_element.style.background = `var(--background-color3)`
 			sub_element.style.filter = `blur(${blur_amount}px)`
-			sub_element.style.width = `${size - 4}px`
-			sub_element.style.height = `${size - 4}px`
+			sub_element.style.width = `${size - 2}px`
+			sub_element.style.height = `${size - 2}px`
 			sub_element.style['border-radius'] = `${size}px`
 			element.style.background = "none"
 			element.appendChild(sub_element)


### PR DESCRIPTION
Fixing a visual glitch that becomes visible when a plugin adds borders to the brushes to make them more visible. Visually transparent for the base Easy Diffusion UI.

See this for context; https://discord.com/channels/1014774730907209781/1058857864954904607/1076694770845487155

Before:
![image](https://user-images.githubusercontent.com/48073125/219972579-d3bd7b6e-ec73-451b-90e6-126ec12417b0.png)

After:
![image](https://user-images.githubusercontent.com/48073125/219972584-e4290c8e-b7cc-433a-bf55-d1d1a878e982.png)
