### PR TITLE
Support custom modifiers with images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ installer
 installer.tar
 dist
 .idea/*
+ui/media/modifier-thumbnails/custom/
+ui/media/modifier-thumbnails/custom/*
+ui/media/modifier-thumbnails/custom/**/*

--- a/scripts/on_env_start.bat
+++ b/scripts/on_env_start.bat
@@ -56,6 +56,10 @@ if "%update_branch%"=="" (
 @copy sd-ui-files\scripts\check_modules.py scripts\ /Y
 @copy "sd-ui-files\scripts\Start Stable Diffusion UI.cmd" . /Y
 @copy "sd-ui-files\scripts\Developer Console.cmd" . /Y
+if exist modifiers\ {
+    mklink ui\media\modifier-thumbnails\custom modifiers
+}
+
 
 @call scripts\on_sd_start.bat
 

--- a/scripts/on_env_start.sh
+++ b/scripts/on_env_start.sh
@@ -41,5 +41,8 @@ cp sd-ui-files/scripts/check_modules.py scripts/
 cp sd-ui-files/scripts/start.sh .
 cp sd-ui-files/scripts/developer_console.sh .
 cp sd-ui-files/scripts/functions.sh scripts/
+if [ -d modifiers ]; then
+    ln -s "$(pwd)/modifiers" ui/media/modifier-thumbnails/custom
+fi
 
 exec ./scripts/on_sd_start.sh

--- a/scripts/on_sd_start.bat
+++ b/scripts/on_sd_start.bat
@@ -139,7 +139,18 @@ set PATH=C:\Windows\System32;%PATH%
 
 call python ..\scripts\check_modules.py uvicorn fastapi
 @if "%ERRORLEVEL%" EQU "0" (
-    echo "Packages necessary for Easy Diffusion were already installed"
+    %$set% FASTAPI_VERSION="python -c ""from importlib.metadata import version; print(version('fastapi') > '0.92.0')"")"
+    @if "%FASTAPI_VERSION%" EQU "False" {
+        echo "Upgrading fastapi"
+
+        @call conda install -c conda-forge -y --update-deps fastapi || (
+            echo "Error installing the packages necessary for Easy Diffusion. Sorry about that, please try to:" & echo "  1. Run this installer again." & echo "  2. If that doesn't fix it, please try the common troubleshooting steps at https://github.com/cmdr2/stable-diffusion-ui/wiki/Troubleshooting" & echo "  3. If those steps don't help, please copy *all* the error messages in this window, and ask the community at https://discord.com/invite/u9yhsFmEkB" & echo "  4. If that doesn't solve the problem, please file an issue at https://github.com/cmdr2/stable-diffusion-ui/issues" & echo "Thanks!"
+            pause
+            exit /b
+        )
+    } else {
+        echo "Packages necessary for Easy Diffusion were already installed"
+    }
 ) else (
     @echo. & echo "Downloading packages necessary for Easy Diffusion..." & echo.
 

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -119,17 +119,28 @@ else
 fi
 
 if python ../scripts/check_modules.py uvicorn fastapi ; then
-    echo "Packages necessary for Easy Diffusion were already installed"
+    FASTAPI_VERSION=$(python -c "from importlib.metadata import version; print(version('fastapi'))")
+    if [[ "$FASTAPI_VERSION" < "0.92.0" ]]; then
+        echo "Upgrading fastapi"
+
+        if conda install -c conda-forge -y --update-deps fastapi ; then
+            echo "Upgraded."
+        else
+            fail "'conda install --update-deps fastapi' failed" 
+        fi
+    else
+        echo "Packages necessary for Easy Diffusion were already installed"
+    fi
 else
     printf "\n\nDownloading packages necessary for Easy Diffusion..\n\n"
 
     export PYTHONNOUSERSITE=1
     export PYTHONPATH="$INSTALL_ENV_DIR/lib/python3.8/site-packages"
 
-    if conda install -c conda-forge -y uvicorn fastapi ; then
+    if conda install -c conda-forge -y --update-deps uvicorn fastapi ; then
         echo "Installed. Testing.."
     else
-        fail "'conda install uvicorn' failed" 
+        fail "'conda install uvicorn fastapi' failed" 
     fi
 
     if ! command -v uvicorn &> /dev/null; then

--- a/ui/easydiffusion/app.py
+++ b/ui/easydiffusion/app.py
@@ -57,8 +57,8 @@ APP_CONFIG_DEFAULTS = {
 
 IMAGE_EXTENSIONS = [".png", ".apng", ".jpg", ".jpeg", ".jfif", ".pjpeg", ".pjp", ".jxl", ".gif", ".webp", ".avif", ".svg"]
 CUSTOM_MODIFIERS_DIR = os.path.join(SD_UI_DIR, "media", "modifier-thumbnails", "custom")
-CUSTOM_MODIFIERS_PORTRAIT_EXTENSIONS=[".portrait", "_portrait", " portrait"]
-CUSTOM_MODIFIERS_LANDSCAPE_EXTENSIONS=[".landscape", "_landscape", " landscape"]
+CUSTOM_MODIFIERS_PORTRAIT_EXTENSIONS=[".portrait", "_portrait", " portrait", "-portrait"]
+CUSTOM_MODIFIERS_LANDSCAPE_EXTENSIONS=[".landscape", "_landscape", " landscape", "-landscape"]
 
 def init():
     os.makedirs(USER_UI_PLUGINS_DIR, exist_ok=True)

--- a/ui/easydiffusion/app.py
+++ b/ui/easydiffusion/app.py
@@ -5,6 +5,7 @@ import json
 import traceback
 import logging
 import shlex
+import urllib
 from rich.logging import RichHandler
 
 from sdkit.utils import log as sdkit_log  # hack, so we can overwrite the log config
@@ -54,6 +55,10 @@ APP_CONFIG_DEFAULTS = {
     },
 }
 
+IMAGE_EXTENSIONS = [".png", ".apng", ".jpg", ".jpeg", ".jfif", ".pjpeg", ".pjp", ".jxl", ".gif", ".webp", ".avif", ".svg"]
+CUSTOM_MODIFIERS_DIR = os.path.join(SD_UI_DIR, "media", "modifier-thumbnails", "custom")
+CUSTOM_MODIFIERS_PORTRAIT_EXTENSIONS=[".portrait", "_portrait", " portrait"]
+CUSTOM_MODIFIERS_LANDSCAPE_EXTENSIONS=[".landscape", "_landscape", " landscape"]
 
 def init():
     os.makedirs(USER_UI_PLUGINS_DIR, exist_ok=True)
@@ -234,3 +239,90 @@ def open_browser():
         import webbrowser
 
         webbrowser.open(f"http://localhost:{port}")
+
+def get_image_modifiers():
+    modifiers_json_path = os.path.join(SD_UI_DIR, "modifiers.json")
+
+    modifier_categories = {}
+    original_category_order=[]
+    with open(modifiers_json_path, "r", encoding="utf-8") as f:
+        modifiers_file = json.load(f)
+
+        # The trailing slash is needed to support symlinks
+        if not os.path.isdir(f"{CUSTOM_MODIFIERS_DIR}/"):
+            return modifiers_file
+
+        # convert modifiers from a list of objects to a dict of dicts
+        for category_item in modifiers_file:
+            category_name = category_item['category']
+            original_category_order.append(category_name)
+            category = {}
+            for modifier_item in category_item['modifiers']:
+                modifier = {}
+                for preview_item in modifier_item['previews']:
+                    modifier[preview_item['name']] = preview_item['path']
+                category[modifier_item['modifier']] = modifier
+            modifier_categories[category_name] = category
+
+    def scan_directory(directory_path, category_name="Modifiers"):
+        for entry in os.scandir(directory_path):
+            if entry.is_file():
+                file_extension = list(filter(lambda e: entry.name.endswith(e), IMAGE_EXTENSIONS))
+                if len(file_extension) == 0:
+                    continue
+
+                modifier_name = entry.name[: -len(file_extension[0])]
+                modifier_path = entry.path[len(CUSTOM_MODIFIERS_DIR) - len("custom/") :]
+                # URL encode path segments
+                modifier_path = "/".join(map(lambda segment: urllib.parse.quote(segment), modifier_path.split("/")))
+                is_portrait = True
+                is_landscape = True
+
+                portrait_extension = list(filter(lambda e: modifier_name.lower().endswith(e), CUSTOM_MODIFIERS_PORTRAIT_EXTENSIONS))
+                landscape_extension = list(filter(lambda e: modifier_name.lower().endswith(e), CUSTOM_MODIFIERS_LANDSCAPE_EXTENSIONS))
+
+                if len(portrait_extension) > 0:
+                    is_landscape = False
+                    modifier_name = modifier_name[: -len(portrait_extension[0])]
+                elif len(landscape_extension) > 0:
+                    is_portrait = False
+                    modifier_name = modifier_name[: -len(landscape_extension[0])]
+                
+                if (category_name not in modifier_categories):
+                    modifier_categories[category_name] = {}
+                
+                category = modifier_categories[category_name]
+
+                if (modifier_name not in category):
+                    category[modifier_name] = {}
+
+                if (is_portrait or "portrait" not in category[modifier_name]):
+                    category[modifier_name]["portrait"] = modifier_path
+                
+                if (is_landscape or "landscape" not in category[modifier_name]):
+                    category[modifier_name]["landscape"] = modifier_path
+            elif entry.is_dir():
+                scan_directory(
+                    entry.path,
+                    entry.name if directory_path==CUSTOM_MODIFIERS_DIR else f"{category_name}/{entry.name}",
+                )
+
+    scan_directory(CUSTOM_MODIFIERS_DIR)
+
+    custom_categories = sorted(
+        [cn for cn in modifier_categories.keys() if cn not in original_category_order],
+        key=str.casefold,
+    )
+
+    # convert the modifiers back into a list of objects
+    modifier_categories_list = []
+    for category_name in [*original_category_order, *custom_categories]:
+        category = { 'category': category_name, 'modifiers': [] }
+        for modifier_name in sorted(modifier_categories[category_name].keys(), key=str.casefold):
+            modifier = { 'modifier': modifier_name, 'previews': [] }
+            for preview_name, preview_path in modifier_categories[category_name][modifier_name].items():
+                modifier['previews'].append({ 'name': preview_name, 'path': preview_path })
+            category['modifiers'].append(modifier)
+        modifier_categories_list.append(category)
+
+    return modifier_categories_list

--- a/ui/easydiffusion/server.py
+++ b/ui/easydiffusion/server.py
@@ -45,7 +45,11 @@ class SetAppConfigRequest(BaseModel):
 
 
 def init():
-    server_api.mount("/media", NoCacheStaticFiles(directory=os.path.join(app.SD_UI_DIR, "media")), name="media")
+    server_api.mount(
+        "/media",
+        NoCacheStaticFiles(directory=os.path.join(app.SD_UI_DIR, "media"), follow_symlink=True),
+        name="media",
+    )
 
     for plugins_dir, dir_prefix in app.UI_PLUGINS_SOURCES:
         server_api.mount(
@@ -156,7 +160,7 @@ def read_web_data_internal(key: str = None):
     elif key == "models":
         return JSONResponse(model_manager.getModels(), headers=NOCACHE_HEADERS)
     elif key == "modifiers":
-        return FileResponse(os.path.join(app.SD_UI_DIR, "modifiers.json"), headers=NOCACHE_HEADERS)
+        return JSONResponse(app.get_image_modifiers(), headers=NOCACHE_HEADERS)
     elif key == "ui_plugins":
         return JSONResponse(app.getUIPlugins(), headers=NOCACHE_HEADERS)
     else:


### PR DESCRIPTION
This change allows adding custom modifiers with images, instead of just text values. It looks for images in a `modifiers` folder and adds them to the object read from `modifiers.json`.  If an image is directly inside of `modifiers` then it will be added to a Modifiers category. Images in direct subfolders will have the folder names as the category. Otherwise images in sub-sub folders etc... will have the folder path be the category (ex: `modifiers/Foo/Bar` will become `Foo/Bar`). The order of categories defined in `modifiers.json` is preserved, and new categories will be added at the end sorted alphabetically.

If the image ends in ` Portrait`, `.Portrait`, `-Portrait`, or `_Portrait` (case insensitive) it will be considered a portrait image, and if it has Landscape instead it would be a landscape image, and the portrait/landscape suffix will be removed from the modifier name. Otherwise the image will be used as both the portrait and landscape.

I am using symlinks to mount it in `ui/media/modifier-thumbnails`. To make symlinks work I had to ensure fastapi is version 0.92.0 or greater.

![image](https://user-images.githubusercontent.com/8977984/219980954-c2b350ab-c3d1-45dc-b6a6-7d04af5b8693.png)
![image](https://user-images.githubusercontent.com/8977984/219980980-df896285-0229-4516-9c71-31d91cde41c6.png)
![image](https://user-images.githubusercontent.com/8977984/219980995-1095b386-bbf0-47a9-8ba6-d18140684c32.png)
![image](https://user-images.githubusercontent.com/8977984/219981075-90f2c758-c136-4901-a040-638c23440f0f.png)
![image](https://user-images.githubusercontent.com/8977984/219981125-02bf603a-d1b1-400c-bc0a-9f8f10b5c3ea.png)
![image](https://user-images.githubusercontent.com/8977984/219981180-f8fef917-94bc-4750-9eb4-9cf2c3618031.png)
![image](https://user-images.githubusercontent.com/8977984/219981157-3e61b812-a362-4bc8-b9eb-72530b60bd05.png)