### PR TITLE
Fix the toggling of image modifiers

### DIFF
--- a/ui/plugins/ui/modifiers-toggle.plugin.js
+++ b/ui/plugins/ui/modifiers-toggle.plugin.js
@@ -40,7 +40,7 @@
                 // refresh activeTags
                 let modifierName = i.parentElement.getElementsByClassName('modifier-card-label')[0].getElementsByTagName("p")[0].dataset.fullName
                 activeTags = activeTags.map(obj => {
-                    if (obj.name === modifierName) {
+                    if (trimModifiers(obj.name) === trimModifiers(modifierName)) {
                         return {...obj, inactive: (obj.element.classList.contains('modifier-toggle-inactive'))};
                     }
                     


### PR DESCRIPTION
The toggling of image modifiers doesn't get properly applied if weights are changed after adding the image modifiers.

Before:
![image](https://user-images.githubusercontent.com/48073125/219983395-5e9487e8-bfdf-4b5f-a861-5e34d4424bec.png)

After:
![image](https://user-images.githubusercontent.com/48073125/219983403-fd03b3a3-98d6-4a32-b1db-1f85704a896b.png)
