### PR TITLE
Don't scan safetensors files

### DIFF
--- a/ui/easydiffusion/model_manager.py
+++ b/ui/easydiffusion/model_manager.py
@@ -158,6 +158,8 @@ def make_model_folders():
 
 def is_malicious_model(file_path):
     try:
+        if file_path.endswith(".safetensors"):
+            return False
         scan_result = scan_model(file_path)
         if scan_result.issues_count > 0 or scan_result.infected_files > 0:
             log.warn(


### PR DESCRIPTION
In newer versions of the picklescanner, scanning of .safetensors files creates an error:

21:28:01.067 ERROR MainThread ERROR: parsing pickle in D:\2.35\dev\models\stable-diffusion\dantionrealmix_10.safetensors: at position 1, opcode b'\xce' unknown

To avoid these entries in the logs, skip scanning of safetensors files.