### PR TITLE
Download all: Fix to download more than 10 images

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1163,14 +1163,15 @@ clearAllPreviewsBtn.addEventListener('click', (e) => { shiftOrConfirm(e, "Clear 
 })})
 
 saveAllImagesBtn.addEventListener('click', (e) => {
+    let i = 0
     document.querySelectorAll(".imageTaskContainer").forEach(container => {
         let req = htmlTaskMap.get(container)
         container.querySelectorAll(".imgContainer img").forEach(img => {
             if (img.closest('.imgItem').style.display === 'none') {
                 return
             }
-
-            onDownloadImageClick(req.reqBody, img)
+            setTimeout(() => {onDownloadImageClick(req, img)}, i*200)
+            i = i+1
         })
     })
 })


### PR DESCRIPTION
Chrome limits the number of downloads in a batch to about 10 to 12. By delaying the downloads by 200ms, many more downloads are possible. Tested with 200.

https://discord.com/channels/1014774730907209781/1021695193499582494/1077218966205902860