### PR TITLE
Fix the active selection's display

### DIFF
--- a/ui/media/css/image-editor.css
+++ b/ui/media/css/image-editor.css
@@ -31,7 +31,7 @@
 }
 
 .editor-options-container > * > *.active {
-	border: 2px solid #3584e4;
+	border: 1px solid #3584e4;
 }
 
 .image_editor_opacity .editor-options-container > * > *:not(.active) {


### PR DESCRIPTION
Yesterday's PR caused a regression on the active brush display, specifically for Sharpness, which is treated differently from the other brushes in the code. This is the fix.

Before:
![image](https://user-images.githubusercontent.com/48073125/220231921-64f893ae-8ad4-4273-a92c-d722106d474a.png)

After:
![image](https://user-images.githubusercontent.com/48073125/220231938-76149b24-133c-427a-8c59-c68f72b73d79.png)
