### PR TITLE
Allow modifier images to be passed as base64 images

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -80,7 +80,7 @@ function createModifierGroup(modifierGroup, initiallyExpanded, removeBy) {
 
     modifiers.forEach(modObj => {
         const modifierName = modObj.modifier
-        const modifierPreviews = modObj?.previews?.map(preview => `${modifierThumbnailPath}/${preview.path}`)
+        const modifierPreviews = modObj?.previews?.map(preview => `${IMAGE_REGEX.test(preview.image) ? preview.image : modifierThumbnailPath + '/' + preview.path}`)
 
         const modifierCard = createModifierCard(modifierName, modifierPreviews, removeBy)
 


### PR DESCRIPTION
No change in existing UI behavior. This change allows image modifier plugins to (optionally) pass the modifier card image as a base64-encoded image.