### PR TITLE
Fix reloading of image tags with weight modifiers

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -167,12 +167,14 @@ function refreshModifiersState(newTags) {
         let found = false
         document.querySelector('#editor-modifiers').querySelectorAll('.modifier-card').forEach(modifierCard => {
             const modifierName = modifierCard.querySelector('.modifier-card-label').innerText
-            if (tag == modifierName) {
+            if (trimModifiers(tag) == trimModifiers(modifierName)) {
                 // add modifier to active array
                 if (!activeTags.map(x => x.name).includes(tag)) { // only add each tag once even if several custom modifier cards share the same tag
+                    const imageModifierCard = modifierCard.cloneNode(true)
+                    imageModifierCard.querySelector('.modifier-card-label p').innerText = tag
                     activeTags.push({
                         'name': modifierName,
-                        'element': modifierCard.cloneNode(true),
+                        'element': imageModifierCard,
                         'originElement': modifierCard
                     })
                 }


### PR DESCRIPTION
Reloading of image tags with ((weight modifiers)) doesn't reuse the modifier card even if it exists, which means images are not restored either. This change fixes that behavior by ensuring proper matching of the tags with existing modifiers.

Original custom modifier:
![image](https://user-images.githubusercontent.com/48073125/220571469-2166d166-5241-4b8d-a1c7-aa0dd6767a0f.png)

Result when reloading weighted image tags:

Before:
![image](https://user-images.githubusercontent.com/48073125/220572397-eb95238b-c4fe-41b3-a17d-1fbab30d65b1.png)

After:
![image](https://user-images.githubusercontent.com/48073125/220571705-3d311448-45c6-46b9-a4fe-98aa7f4dab90.png)
