### PR TITLE
Fix the display of the Preview options button

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -306,6 +306,7 @@
                             </div>
                         </div>
                     </div>
+                    <div class="clearfix" style="clear: both;"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The preview options button overlaps the image task container when the window width is reduced because of the float:right property of the button. This technique makes the toolbar container grow as needed when it contains a floated element, resulting in cleaner display.

Before:
![image](https://user-images.githubusercontent.com/48073125/220813513-f6686d9f-9cc1-48f4-b004-20519e5cc10a.png)

After:
![image](https://user-images.githubusercontent.com/48073125/220813524-a2d71f09-1af3-4df9-972e-d217b350f70c.png)

To confirm, the UI displays as usual when the window is large enough (no change):
![image](https://user-images.githubusercontent.com/48073125/220814017-3da79848-8421-4ff0-8ed9-c9246dc72407.png)
