### PR TITLE
Fix the restoration of the inpainting toggle

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -357,6 +357,7 @@ function restoreTaskToUI(task, fieldsToSkip) {
         initImagePreview.addEventListener('load', function() {
             if (Boolean(task.reqBody.mask)) {
                 imageInpainter.setImg(task.reqBody.mask)
+                maskSetting.checked = true
             }
         }, { once: true })
         initImagePreview.src = task.reqBody.init_image


### PR DESCRIPTION
The Inpainting toggle doesn't get restored at the very first attempt.

Repro steps:
1. Create a task with a source image and enable the inpainting toggle.
2. Copy the task to the clipboard
3. Refresh the page (F5)
4. Paste the task from the clipboard

Expected result:
The task gets restored and the toggle is ON.

Actual result:
The task is restored, but the toggle is OFF.

To fix that, we have to restore the toggle's state after loading the source image.

Before (upon initial task restoration):
![image](https://user-images.githubusercontent.com/48073125/220848088-8711aabf-e44e-469f-a4af-75d532405ddd.png)

After (upon initial task restoration):
![image](https://user-images.githubusercontent.com/48073125/220848440-611632a7-4191-4082-b604-fab411e1f40a.png)
