### PR TITLE
DOM tweaking to identify modifier categories

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -115,7 +115,7 @@ function createModifierGroup(modifierGroup, initiallyExpanded, removeBy) {
     modifiersEl.appendChild(brk)
 
     let e = document.createElement('div')
-    e.className = 'custom-modifier-category'
+    e.className = 'modifier-category'
     e.appendChild(titleEl)
     e.appendChild(modifiersEl)
 

--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -115,6 +115,7 @@ function createModifierGroup(modifierGroup, initiallyExpanded, removeBy) {
     modifiersEl.appendChild(brk)
 
     let e = document.createElement('div')
+    e.className = 'custom-modifier-category'
     e.appendChild(titleEl)
     e.appendChild(modifiersEl)
 


### PR DESCRIPTION
This is purely a DOM update to be able to identify the category a given image modifier is part of - e.g. using .closest(). No UI change.

![image](https://user-images.githubusercontent.com/48073125/221139821-2dff859b-6dfe-4a2c-8a15-e9220bbf0327.png)

Sample code using this mechanism in an upcoming plugin:
const category = imageElement.closest('.custom-modifier-category').querySelector('h5').innerText.slice(1)
