### PR TITLE
Refresh the image count as user types

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1197,7 +1197,9 @@ function renameMakeImageButton() {
     }
 }
 numOutputsTotalField.addEventListener('change', renameMakeImageButton)
+numOutputsTotalField.addEventListener('keyup', renameMakeImageButton)
 numOutputsParallelField.addEventListener('change', renameMakeImageButton)
+numOutputsParallelField.addEventListener('keyup', renameMakeImageButton)
 
 function onDimensionChange() {
     let widthValue = parseInt(widthField.value)

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1197,9 +1197,9 @@ function renameMakeImageButton() {
     }
 }
 numOutputsTotalField.addEventListener('change', renameMakeImageButton)
-numOutputsTotalField.addEventListener('keyup', renameMakeImageButton)
+numOutputsTotalField.addEventListener('keyup', debounce(renameMakeImageButton, 300))
 numOutputsParallelField.addEventListener('change', renameMakeImageButton)
-numOutputsParallelField.addEventListener('keyup', renameMakeImageButton)
+numOutputsParallelField.addEventListener('keyup', debounce(renameMakeImageButton, 300))
 
 function onDimensionChange() {
     let widthValue = parseInt(widthField.value)


### PR DESCRIPTION
Currently I have to change the focus for the image count to refresh. This change makes it immediate. I've been wondering if 'change' should merely be replaced by 'keyup' but decided against it for accessibility reasons (people who might be using accessibility tools with alternative input methods).

Hope this works for you.