### PR TITLE
Make the image editor scrollable as needed

### DIFF
--- a/ui/media/css/image-editor.css
+++ b/ui/media/css/image-editor.css
@@ -149,16 +149,21 @@
 	pointer-events: none;
 }
 
-
 .image-editor-popup {
 	--popup-margin: 16px;
 	--popup-padding: 24px;
 }
 
+@media screen and (min-width: 700px) {
+	.image-editor-popup {
+		overflow-y: auto;
+	}
+}
+
 .image-editor-popup > div {
 	margin: var(--popup-margin);
 	padding: var(--popup-padding);
-	min-height: calc(100vh - (2 * var(--popup-margin)));
+	min-height: calc(99h - (2 * var(--popup-margin)));
 	max-width: none;
 	min-width: fit-content;
 }
@@ -186,7 +191,7 @@
 
 
 .image-editor-popup > div > div {
-	min-height: calc(100vh - (2 * var(--popup-margin)) - (2 * var(--popup-padding)));
+	min-height: calc(99vh - (2 * var(--popup-margin)) - (2 * var(--popup-padding)));
 }
 
 .inpainter .image_editor_color {


### PR DESCRIPTION
Some users on 4K screens zoom in their browser display, but this causes the editor buttons on the top right to be out of view, and since the editor is not scrollable, they have to zoom out to be able to hit 'save'.

This change fixes that by making the image editor window vertically scrollable if it gets too large. No UI change on smaller screens (e.g. phones).

Before:
![image](https://user-images.githubusercontent.com/48073125/221379528-37048b11-7534-4598-acd2-7d2b24abfc66.png)

After:
![image](https://user-images.githubusercontent.com/48073125/221379569-6c564b32-910e-410b-8080-1178bcfc553e.png)
