### PR TITLE
Select model by clicking on the file icon itself

### DIFF
--- a/ui/media/js/searchable-models.js
+++ b/ui/media/js/searchable-models.js
@@ -110,8 +110,9 @@ class ModelDropdown
     
     processClick(e) {
         e.preventDefault()
-        if (e.srcElement.classList.contains('model-file')) {
-            this.saveCurrentSelection(e.srcElement, e.srcElement.innerText, e.srcElement.dataset.path)
+        if (e.srcElement.classList.contains('model-file') || e.srcElement.classList.contains('fa-file')) {
+            const elem = e.srcElement.classList.contains('model-file') ? e.srcElement : e.srcElement.parentElement
+            this.saveCurrentSelection(elem, elem.innerText, elem.dataset.path)
             this.hideModelList()
             this.modelFilter.focus()
             this.modelFilter.select()


### PR DESCRIPTION
Currently one has to click on the model name to select a model. Clicking on the file icon won't work and doesn't do anything. This change fixes that behavior by allowing the user to click on either the model name or the file icon to select a model.