### PR TITLE
Preserve full names for shortened modifiers

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -167,11 +167,12 @@ function refreshModifiersState(newTags) {
         let found = false
         document.querySelector('#editor-modifiers').querySelectorAll('.modifier-card').forEach(modifierCard => {
             const modifierName = modifierCard.querySelector('.modifier-card-label p').dataset.fullName
+            const shortModifierName = modifierCard.querySelector('.modifier-card-label p').innerText
             if (trimModifiers(tag) == trimModifiers(modifierName)) {
                 // add modifier to active array
                 if (!activeTags.map(x => x.name).includes(tag)) { // only add each tag once even if several custom modifier cards share the same tag
                     const imageModifierCard = modifierCard.cloneNode(true)
-                    imageModifierCard.querySelector('.modifier-card-label p').innerText = tag
+                    imageModifierCard.querySelector('.modifier-card-label p').innerText = shortModifierName
                     activeTags.push({
                         'name': modifierName,
                         'element': imageModifierCard,

--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -166,7 +166,7 @@ function refreshModifiersState(newTags) {
     newTags.forEach(tag => {
         let found = false
         document.querySelector('#editor-modifiers').querySelectorAll('.modifier-card').forEach(modifierCard => {
-            const modifierName = modifierCard.querySelector('.modifier-card-label').innerText
+            const modifierName = modifierCard.querySelector('.modifier-card-label p').dataset.fullName
             if (trimModifiers(tag) == trimModifiers(modifierName)) {
                 // add modifier to active array
                 if (!activeTags.map(x => x.name).includes(tag)) { // only add each tag once even if several custom modifier cards share the same tag

--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -154,7 +154,7 @@ async function loadModifiers() {
 function refreshModifiersState(newTags) {
     // clear existing modifiers
     document.querySelector('#editor-modifiers').querySelectorAll('.modifier-card').forEach(modifierCard => {
-        const modifierName = modifierCard.querySelector('.modifier-card-label').innerText
+        const modifierName = modifierCard.querySelector('.modifier-card-label p').dataset.fullName // pick the full modifier name
         if (activeTags.map(x => x.name).includes(modifierName)) {
             modifierCard.classList.remove(activeCardClass)
             modifierCard.querySelector('.modifier-card-image-overlay').innerText = '+'

--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -48,7 +48,6 @@ function createModifierCard(name, previews, removeBy) {
 
     if(cardLabel.length <= maxLabelLength) {
         label.querySelector('p').innerText = cardLabel
-        label.querySelector('p').dataset.fullName = name // preserve the full name
     } else {
         const tooltipText = document.createElement('span')
         tooltipText.className = 'tooltip-text'
@@ -59,6 +58,7 @@ function createModifierCard(name, previews, removeBy) {
 
         label.querySelector('p').innerText = cardLabel.substring(0, maxLabelLength) + '...'
     }
+    label.querySelector('p').dataset.fullName = name // preserve the full name
 
     return modifierCard
 }


### PR DESCRIPTION
The PR https://github.com/cmdr2/stable-diffusion-ui/pull/779/files added code to preserve the full names of truncated image modifiers, but only in the "short image modifiers" code path. This PR fixes that by preserving the full image modifier in the DOM for both regular and truncated modifier names and making sure the right string is used (full string for comparisons, shortened string for display).