### PR TITLE
Fix restoration of weighted tasks with truncated modifiers

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -173,9 +173,9 @@ function refreshModifiersState(newTags) {
                 // add modifier to active array
                 if (!activeTags.map(x => x.name).includes(tag)) { // only add each tag once even if several custom modifier cards share the same tag
                     const imageModifierCard = modifierCard.cloneNode(true)
-                    imageModifierCard.querySelector('.modifier-card-label p').innerText = shortModifierName
+                    imageModifierCard.querySelector('.modifier-card-label p').innerText = tag.replace(modifierName, shortModifierName)
                     activeTags.push({
-                        'name': modifierName,
+                        'name': tag,
                         'element': imageModifierCard,
                         'originElement': modifierCard
                     })

--- a/ui/media/js/utils.js
+++ b/ui/media/js/utils.js
@@ -265,7 +265,7 @@ function BraceExpander() {
         let toS = function (x) {
             return x.toString();
         };
-    
+
         return str.split(/(\\\\)/).filter(toS).reduce(function (a, s) {
             return a.concat(s.charAt(0) === '\\' ? s : s.split(
                 /(\\*[{,}])/

--- a/ui/media/js/utils.js
+++ b/ui/media/js/utils.js
@@ -267,11 +267,9 @@ function BraceExpander() {
         };
     
         return str.split(/(\\\\)/).filter(toS).reduce(function (a, s) {
-            return a.concat(s.charAt(0) === '\\' ? s.trim() : s.split(
+            return a.concat(s.charAt(0) === '\\' ? s : s.split(
                 /(\\*[{,}])/
-            ).filter(toS).map(function (x) {
-                return x.trim();
-            }));
+            ).filter(toS));
         }, []);
     }
 

--- a/ui/media/js/utils.js
+++ b/ui/media/js/utils.js
@@ -265,11 +265,13 @@ function BraceExpander() {
         let toS = function (x) {
             return x.toString();
         };
-
+    
         return str.split(/(\\\\)/).filter(toS).reduce(function (a, s) {
-            return a.concat(s.charAt(0) === '\\' ? s : s.split(
+            return a.concat(s.charAt(0) === '\\' ? s.trim() : s.split(
                 /(\\*[{,}])/
-            ).filter(toS));
+            ).filter(toS).map(function (x) {
+                return x.trim();
+            }));
         }, []);
     }
 

--- a/ui/plugins/ui/Modifiers-wheel.plugin.js
+++ b/ui/plugins/ui/Modifiers-wheel.plugin.js
@@ -26,15 +26,25 @@
     
                     const delta = Math.sign(event.deltaY)
                     let s = i.parentElement.getElementsByClassName('modifier-card-label')[0].getElementsByTagName("p")[0].innerText
+                    let t
+                    // find the corresponding tag
+                    for (let it = 0; it < overlays.length; it++) {
+                        if (i == overlays[it]) {
+                            t = activeTags[it].name
+                            break
+                        }
+                    }
                     if (delta < 0) {
                         // wheel scrolling up
                         if (s.substring(0, 1) == '[' && s.substring(s.length-1) == ']') {
                             s = s.substring(1, s.length - 1)
+                            t = t.substring(1, t.length - 1)
                         }
                         else
                         {
                             if (s.substring(0, 10) !== '('.repeat(10) && s.substring(s.length-10) !== ')'.repeat(10)) {
                                 s = '(' + s + ')'
+                                t = '(' + t + ')'
                             }
                         }
                     }
@@ -42,11 +52,13 @@
                         // wheel scrolling down
                         if (s.substring(0, 1) == '(' && s.substring(s.length-1) == ')') {
                             s = s.substring(1, s.length - 1)
+                            t = t.substring(1, t.length - 1)
                         }
                         else
                         {
                             if (s.substring(0, 10) !== '['.repeat(10) && s.substring(s.length-10) !== ']'.repeat(10)) {
                                 s = '[' + s + ']'
+                                t = '[' + t + ']'
                             }
                         }
                     }
@@ -54,7 +66,7 @@
                     // update activeTags
                     for (let it = 0; it < overlays.length; it++) {
                         if (i == overlays[it]) {
-                            activeTags[it].name = s
+                            activeTags[it].name = t
                             break
                         }
                     }


### PR DESCRIPTION
Restoration of image tags comprising (((weighted modifiers with truncated nam...))) was broken because the code relied on the shorted modifier (with the ...) and added that to activeTags. On top of that, weights were lost during the restoration process because the code restored the non-weighted image modifiers.
Finally, modifiers passed as weighted enumerations (e.g. (({modifier1, modifier2, modifier3})) are parsed as ((modifier1)), (( modifier2), and (( modifier3)). Notice the extra spaces.

With this fix, reloading tasks and plugins restoring weighted and/or truncated modifiers should work as expected. Also opportunistically fixed the trimming of (({modifier1, modifier2, modifier3})) to properly compute as ((modifier1)), ((modifier2)), and ((modifier3)), i.e. without the extra spaces.