### PR TITLE
Add support for MPS when running on Apple silicon

### DIFF
--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -285,6 +285,7 @@ printf "\n\nEasy Diffusion installation complete, starting the server!\n\n"
 
 SD_PATH=`pwd`
 
+export PYTORCH_ENABLE_MPS_FALLBACK=1
 export PYTHONPATH="$INSTALL_ENV_DIR/lib/python3.8/site-packages"
 echo "PYTHONPATH=$PYTHONPATH"
 

--- a/ui/easydiffusion/task_manager.py
+++ b/ui/easydiffusion/task_manager.py
@@ -385,7 +385,7 @@ def get_devices():
     }
 
     def get_device_info(device):
-        if device == "cpu":
+        if "cuda" not in device:
             return {"name": device_manager.get_processor_name()}
 
         mem_free, mem_total = torch.cuda.mem_get_info(device)


### PR DESCRIPTION
Changes:

* autodetect if MPS is available and if the pytorch version has MPS support.
* change logic from "is the device CPU?" to "is the device not CUDA?".
* set PYTORCH_ENABLE_MPS_FALLBACK=1

Known issues:

* Some samplers (eg DDIM) will fail on MPS unless forced to CPU-only mode