### PR TITLE
Fix autosave of modifiers image style

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -18,6 +18,9 @@ const CUSTOM_MODIFIERS_KEY = "customModifiers"
 
 function createModifierCard(name, previews, removeBy) {
     const modifierCard = document.createElement('div')
+    let style = previewImageField.value
+    let styleIndex = (style=='portrait') ? 0 : 1
+
     modifierCard.className = 'modifier-card'
     modifierCard.innerHTML = `
     <div class="modifier-card-overlay"></div>
@@ -37,8 +40,8 @@ function createModifierCard(name, previews, removeBy) {
     errorText.innerText = 'No Image'
 
     if (typeof previews == 'object') {
-        image.src = previews[0]; // portrait
-        image.setAttribute('preview-type', 'portrait')
+        image.src = previews[styleIndex]; // portrait
+        image.setAttribute('preview-type', style)
     } else {
         image.remove()
     }


### PR DESCRIPTION
https://discord.com/channels/1014774730907209781/1014774732018683926/1083821795427233973
![image](https://user-images.githubusercontent.com/5852422/224421440-dbec417b-f4b4-4c4d-951c-b3efbf6d5b55.png)
Even though the image style gets saved, the setting doesn't get applied when loading the page.