### PR TITLE
Notify plugins when image tags get refreshed

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -261,6 +261,7 @@ function refreshTagsList() {
     let brk = document.createElement('br')
     brk.style.clear = 'both'
     editorModifierTagsList.appendChild(brk)
+    document.dispatchEvent(new Event('refreshImageModifiers')) // notify plugins that the image tags have been refreshed 
 }
 
 function toggleCardState(modifierName, makeActive) {


### PR DESCRIPTION
Image modifiers may be temporarily hidden by plugins like searchable modifier search box, and when restoring a task (e.g. use settings) the image modifier s copied with the hidden class set, which makes it look like it's missing.

By notifying plugins that the image tags have been refreshed, it allows it to act accordingly (in this case by making sure image tags are visible).

Before:
![image](https://user-images.githubusercontent.com/48073125/224535849-c6ce51d2-d978-4dbc-a8de-79af34c91efe.png)

After:
![image](https://user-images.githubusercontent.com/48073125/224535853-83456ffa-b6be-4e0e-bdb8-277203f8f375.png)
