### PR TITLE
Only delete task sections if they are no longer processing

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -288,7 +288,10 @@ function showImages(reqBody, res, outputContainer, livePreview) {
                             allHidden = false;
                         }
                     }
-                    if(allHidden === true) {parentTaskContainer.classList.add("displayNone")}
+                    if(allHidden === true) {
+                        const req = htmlTaskMap.get(parentTaskContainer)
+                        if(!req.isProcessing || req.batchesDone == req.batchCount) {parentTaskContainer.classList.add("displayNone")}
+                    }
                 })
             })
         }


### PR DESCRIPTION
When using the "close image"-X button, the task section gets removed when the last image in the section gets deleted. If the batch has not been completed yet, the remaining images get rendered to a hidden task section. 

This PR prevents the deletion of the task section while it is still processing.
https://discord.com/channels/1014774730907209781/1014774732018683928/1084938951271403550