### PR TITLE
Hardcode CSS content type

### DIFF
--- a/ui/easydiffusion/server.py
+++ b/ui/easydiffusion/server.py
@@ -16,6 +16,8 @@ from easydiffusion import app, model_manager, task_manager
 from easydiffusion.types import TaskData, GenerateImageRequest, MergeRequest
 from easydiffusion.utils import log
 
+import mimetypes
+
 log.info(f"started in {app.SD_DIR}")
 log.info(f"started at {datetime.datetime.now():%x %X}")
 
@@ -52,6 +54,9 @@ class SetAppConfigRequest(BaseModel):
 
 
 def init():
+    mimetypes.init()
+    mimetypes.add_type('text/css', '.css')
+
     if os.path.isdir(app.CUSTOM_MODIFIERS_DIR):
         server_api.mount(
             "/media/modifier-thumbnails/custom",


### PR DESCRIPTION
By default, uvicorn uses the 'Content Type' value from 'Computer\HKEY_CLASSES_ROOT\.css' for the Content-Type header in its responses. Some systems have this set to 'application/x-css', an outdated content type used in the early days of CSS. Modern browsers ignore stylesheets that don't have the content-type 'text/css'. This change hardcodes the Content-Type to 'text/css', ignoring the registry.

https://discord.com/channels/1014774730907209781/1084874689769377892
https://discord.com/channels/1014774730907209781/1072804725017280553