### PR TITLE
Fix #1012 - Image Modifiers > Thumbnail Size slider remembers its pos…

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -149,10 +149,11 @@ async function loadModifiers() {
             createCollapsibles(editorModifierEntries)
         }
     } catch (e) {
-        console.log('error fetching modifiers', e)
+        console.error('error fetching modifiers', e)
     }
 
     loadCustomModifiers()
+    resizeModifierCards(modifierCardSizeSlider.value)
     document.dispatchEvent(new Event('loadImageModifiers'))
 }
 


### PR DESCRIPTION
…ition but does not apply it at page load

Loading of settings happens before the modifiers have been loaded, so the setting loader's triggering of 'change' events happens too early.