### PR TITLE
remove task from dome when removing images

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -302,7 +302,7 @@ function showImages(reqBody, res, outputContainer, livePreview) {
                     }
                     if(allHidden === true) {
                         const req = htmlTaskMap.get(parentTaskContainer)
-                        if(!req.isProcessing || req.batchesDone == req.batchCount) {parentTaskContainer.classList.add("displayNone")}
+                        if(!req.isProcessing || req.batchesDone == req.batchCount) {parentTaskContainer.parentNode.removeChild(parentTaskContainer)}
                     }
                 })
             })


### PR DESCRIPTION
Changing the functionality to remove task from dom when all images have been removed. This will save system memory in the browser allowing better performance.