### PR TITLE
When zooming, only show one copy of the image

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -322,15 +322,15 @@ function showImages(reqBody, res, outputContainer, livePreview) {
             imageModal(this.src)
         })
 
-        const imageExpandBtn = imageItemElem.querySelector('.imgExpandBtn')
-        imageExpandBtn.addEventListener('click', function() {
-            imageModal(imageElem.src)
-        })
-
         const imageInfo = imageItemElem.querySelector('.imgItemInfo')
         imageInfo.style.visibility = (livePreview ? 'hidden' : 'visible')
 
         if ('seed' in result && !imageElem.hasAttribute('data-seed')) {
+            const imageExpandBtn = imageItemElem.querySelector('.imgExpandBtn')
+            imageExpandBtn.addEventListener('click', function() {
+                imageModal(imageElem.src)
+            })
+
             const req = Object.assign({}, reqBody, {
                 seed: result?.seed || reqBody.seed
             })

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -318,9 +318,6 @@ function showImages(reqBody, res, outputContainer, livePreview) {
         imageElem.addEventListener('load', function() {
             imageItemElem.querySelector('.img_bottom_label').innerText = `${this.naturalWidth} x ${this.naturalHeight}`
         })
-        imageElem.addEventListener('click', function() {
-            imageModal(this.src)
-        })
 
         const imageInfo = imageItemElem.querySelector('.imgItemInfo')
         imageInfo.style.visibility = (livePreview ? 'hidden' : 'visible')
@@ -329,6 +326,9 @@ function showImages(reqBody, res, outputContainer, livePreview) {
             const imageExpandBtn = imageItemElem.querySelector('.imgExpandBtn')
             imageExpandBtn.addEventListener('click', function() {
                 imageModal(imageElem.src)
+            })
+            imageElem.addEventListener('click', function() {
+                imageModal(this.src)
             })
 
             const req = Object.assign({}, reqBody, {


### PR DESCRIPTION
Don't add a copy of the image for each live preview image shown:
![image](https://user-images.githubusercontent.com/5852422/225464383-0fbb2966-fe70-410e-9dfb-a8d31bcfdc7d.png)
