### PR TITLE
Support custom folder filename formats

### DIFF
--- a/ui/easydiffusion/types.py
+++ b/ui/easydiffusion/types.py
@@ -45,6 +45,9 @@ class TaskData(BaseModel):
     stream_image_progress: bool = False
     stream_image_progress_interval: int = 5
 
+    folder_format: str = "$id"
+    filename_format: str = "$p_$tsb64"
+
 
 class MergeRequest(BaseModel):
     model0: str = None

--- a/ui/easydiffusion/utils/save_utils.py
+++ b/ui/easydiffusion/utils/save_utils.py
@@ -3,11 +3,15 @@ import time
 import base64
 import re
 
+from easydiffusion import app
 from easydiffusion.types import TaskData, GenerateImageRequest
+from functools import reduce
+from datetime import datetime
 
 from sdkit.utils import save_images, save_dicts
 
 filename_regex = re.compile("[^a-zA-Z0-9._-]")
+img_number_regex = re.compile("([0-9]{5,})")
 
 # keep in sync with `ui/media/js/dnd.js`
 TASK_TEXT_MAPPING = {
@@ -29,12 +33,66 @@ TASK_TEXT_MAPPING = {
     "hypernetwork_strength": "Hypernetwork Strength",
 }
 
+time_placeholders = {
+    "$yyyy": "%Y",
+    "$MM": "%m",
+    "$dd": "%d",
+    "$HH": "%H",
+    "$mm": "%M",
+    "$ss": "%S",
+}
+
+other_placeholders = {
+    "$id": lambda req, task_data: filename_regex.sub("_", task_data.session_id),
+    "$p": lambda req, task_data: filename_regex.sub("_", req.prompt)[:50],
+    "$s": lambda req, task_data: str(req.seed),
+}
+
+def format_placeholders(format: str, req: GenerateImageRequest, task_data: TaskData, now = None):
+    if now is None:
+        now = time.time()
+
+    for placeholder, time_format in time_placeholders.items():
+        if placeholder in format:
+            format = format.replace(placeholder, datetime.fromtimestamp(now).strftime(time_format))
+    for placeholder, replace_func in other_placeholders.items():
+        if placeholder in format:
+            format = format.replace(placeholder, replace_func(req, task_data))
+
+    return format
+
+def format_folder_name(req: GenerateImageRequest, task_data: TaskData):
+    format = format_placeholders(task_data.folder_format, req, task_data)
+    return filename_regex.sub("_", format)
+
+def format_file_name(
+    req: GenerateImageRequest,
+    task_data: TaskData,
+    now: float,
+    batch_file_number: int,
+    folder_img_number: int,
+):
+    format = format_placeholders(task_data.filename_format, req, task_data, now)
+    
+    if "$n" in format:
+        format = format.replace("$n", f"{folder_img_number:05}")
+    
+    if "$tsb64" in format:
+        img_id = base64.b64encode(int(now + batch_file_number).to_bytes(8, "big")).decode()  # Generate unique ID based on time.
+        img_id = img_id.translate({43: None, 47: None, 61: None})[-8:]  # Remove + / = and keep last 8 chars.
+        format = format.replace("$tsb64", img_id)
+    
+    if "$ts" in format:
+        format = format.replace("$ts", str(int(now) + batch_file_number))
+
+    return filename_regex.sub("_", format)
 
 def save_images_to_disk(images: list, filtered_images: list, req: GenerateImageRequest, task_data: TaskData):
     now = time.time()
-    save_dir_path = os.path.join(task_data.save_to_disk_path, filename_regex.sub("_", task_data.session_id))
+    save_dir_path = os.path.join(task_data.save_to_disk_path, format_folder_name(req, task_data))
     metadata_entries = get_metadata_entries_for_request(req, task_data)
-    make_filename = make_filename_callback(req, now=now)
+    file_number = calculate_img_number(save_dir_path, task_data)
+    make_filename = make_filename_callback(req, task_data, file_number, now=now)
 
     if task_data.show_only_filtered_image or filtered_images is images:
         save_images(
@@ -53,7 +111,7 @@ def save_images_to_disk(images: list, filtered_images: list, req: GenerateImageR
                 file_format=task_data.output_format,
             )
     else:
-        make_filter_filename = make_filename_callback(req, now=now, suffix="filtered")
+        make_filter_filename = make_filename_callback(req, task_data, file_number, now=now, suffix="filtered")
 
         save_images(
             images,
@@ -116,17 +174,62 @@ def get_printable_request(req: GenerateImageRequest):
     return metadata
 
 
-def make_filename_callback(req: GenerateImageRequest, suffix=None, now=None):
+def make_filename_callback(
+    req: GenerateImageRequest,
+    task_data: TaskData,
+    folder_img_number: int,
+    suffix=None,
+    now=None,
+):
     if now is None:
         now = time.time()
 
     def make_filename(i):
-        img_id = base64.b64encode(int(now + i).to_bytes(8, "big")).decode()  # Generate unique ID based on time.
-        img_id = img_id.translate({43: None, 47: None, 61: None})[-8:]  # Remove + / = and keep last 8 chars.
-
-        prompt_flattened = filename_regex.sub("_", req.prompt)[:50]
-        name = f"{prompt_flattened}_{img_id}"
+        name = format_file_name(req, task_data, now, i, folder_img_number)
         name = name if suffix is None else f"{name}_{suffix}"
+
         return name
 
     return make_filename
+
+def calculate_img_number(save_dir_path: str, task_data: TaskData):
+    def get_highest_img_number(accumulator: int, file: os.DirEntry) -> int:
+        if not file.is_file:
+            return accumulator
+        
+        if len(list(filter(lambda e: file.name.endswith(e), app.IMAGE_EXTENSIONS))) == 0:
+            return accumulator
+        
+        get_highest_img_number.number_of_images = get_highest_img_number.number_of_images + 1
+        
+        number_match = img_number_regex.match(file.name)
+        if not number_match:
+            return accumulator
+        
+        file_number = number_match.group().lstrip('0')
+        
+        # Handle 00000
+        return int(file_number) if file_number else 0
+    
+    get_highest_img_number.number_of_images = 0
+    
+    highest_file_number = -1
+
+    if os.path.isdir(save_dir_path):
+        existing_files = list(os.scandir(save_dir_path))
+        highest_file_number = reduce(get_highest_img_number, existing_files, -1)
+
+    calculated_img_number = max(highest_file_number, get_highest_img_number.number_of_images - 1)
+
+    if task_data.session_id in calculate_img_number.session_img_numbers:
+        calculated_img_number = max(
+            calculate_img_number.session_img_numbers[task_data.session_id],
+            calculated_img_number,
+        )
+    
+    calculated_img_number = calculated_img_number + 1
+    
+    calculate_img_number.session_img_numbers[task_data.session_id] = calculated_img_number
+    return calculated_img_number
+
+calculate_img_number.session_img_numbers = {}

--- a/ui/media/js/auto-save.js
+++ b/ui/media/js/auto-save.js
@@ -49,7 +49,9 @@ const SETTINGS_IDS_LIST = [
     "auto_scroll",
     "zip_toggle",
     "tree_toggle",
-    "json_toggle"
+    "json_toggle",
+    "folder_format",
+    "filename_format",
 ]
 
 const IGNORE_BY_DEFAULT = [

--- a/ui/media/js/engine.js
+++ b/ui/media/js/engine.js
@@ -744,6 +744,9 @@
         "block_nsfw": false,
         "output_format": "png",
         "output_quality": 75,
+
+        "folder_format": '$id',
+        "filename_format": '$p_$tsb64',
     }
     const TASK_OPTIONAL = {
         "device": 'string',

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1056,7 +1056,9 @@ function getCurrentUserRequest() {
             metadata_output_format: metadataOutputFormatField.value,
             original_prompt: promptField.value,
             active_tags: (activeTags.map(x => x.name)),
-            inactive_tags: (activeTags.filter(tag => tag.inactive === true).map(x => x.name))
+            inactive_tags: (activeTags.filter(tag => tag.inactive === true).map(x => x.name)),,
+            folder_format: folderFormatField.value,
+            filename_format: filenameFormatField.value,
         }
     }
     if (IMAGE_REGEX.test(initImagePreview.src)) {


### PR DESCRIPTION
Add two new settings: folder format and filename format. They both support placeholders for the prompt, seed, and datetime components. The filenames also support the image number in the folder and two representations of the timestamp.

The default values should generate the exact same values that are currently being generated. When loading the settings, if the format is the default value the default radio button will be checked. When the custom radio button is checked, it'll show an input field and a list of supported placeholders, and when the default is checked both will be hidden. The folder format does support seeds, minutes, and seconds, but I didn't include that in the UI for folders.

![image](https://user-images.githubusercontent.com/8977984/225503475-8695b166-a657-411c-bd97-b1dfc31a88f3.png)
![image](https://user-images.githubusercontent.com/8977984/225503592-deb10000-31e8-445f-ae03-06a70e843618.png)
![image](https://user-images.githubusercontent.com/8977984/225504350-6874e6b5-7642-4ff4-aa60-cf6ef5189444.png)
