### PR TITLE
Load prompt: support JSON and TXT metadata

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -490,6 +490,7 @@ async function parseContent(text) {
         return true
     } else {
         console.warn(`Raw text content couldn't be parsed.`)
+        promptField.value = text
         return false
     }
 }

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1582,7 +1582,7 @@ promptsFromFileBtn.addEventListener('click', function() {
     promptsFromFileSelector.click()
 })
 
-promptsFromFileSelector.addEventListener('change', function() {
+promptsFromFileSelector.addEventListener('change', async function() {
     if (promptsFromFileSelector.files.length === 0) {
         return
     }
@@ -1590,8 +1590,8 @@ promptsFromFileSelector.addEventListener('change', function() {
     let reader = new FileReader()
     let file = promptsFromFileSelector.files[0]
 
-    reader.addEventListener('load', function() {
-        promptField.value = reader.result
+    reader.addEventListener('load', async function() {
+        await parseContent(reader.result)
     })
 
     if (file) {


### PR DESCRIPTION
Also, allow prompt files (one line per prompt) to be dnd'ed