### PR TITLE
Prevent collisions of 'What's new' and the server status

### DIFF
--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -831,7 +831,7 @@ input::file-selector-button {
 }
 
 /* Small screens */
-@media screen and (max-width: 1265px) {
+@media screen and (max-width: 1365px) {
     #top-nav {
         flex-direction: column;
     }


### PR DESCRIPTION
With the current setting of 1265px, the status and the tab headers overlap:
![image](https://user-images.githubusercontent.com/5852422/226191346-1d6d4309-a5a8-4446-911d-46e07f2ccc26.png)
