### PR TITLE
Add 'Karras' tag to DPM samplers

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -154,11 +154,11 @@
                             <option value="dpm2_a">DPM2 Ancestral</option>
                             <option value="lms">LMS</option>
                             <option value="dpm_solver_stability">DPM Solver (Stability AI)</option>
-                            <option value="dpmpp_2s_a">DPM++ 2s Ancestral</option>
-                            <option value="dpmpp_2m">DPM++ 2m</option>
-                            <option value="dpmpp_sde">DPM++ SDE</option>
-                            <option value="dpm_fast">DPM Fast</option>
-                            <option value="dpm_adaptive">DPM Adaptive</option>
+                            <option value="dpmpp_2s_a">DPM++ 2s Ancestral (Karras)</option>
+                            <option value="dpmpp_2m">DPM++ 2m (Karras)</option>
+                            <option value="dpmpp_sde">DPM++ SDE (Karras)</option>
+                            <option value="dpm_fast">DPM Fast (Karras)</option>
+                            <option value="dpm_adaptive">DPM Adaptive (Karras)</option>
                             <option value="unipc_snr">UniPC SNR</option>
                             <option value="unipc_tu">UniPC TU</option>
                             <option value="unipc_snr_2">UniPC SNR 2</option>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5852422/226360886-193399cf-7de4-4027-b024-c25e1e52e3b9.png)

Alternatively, `<optgroup>` could be used, but it uses more space, adding a scrollbar to the dropdown:
![image](https://user-images.githubusercontent.com/5852422/226362412-38e1d518-1136-4d40-b060-146f6dea5f95.png)
