### PR TITLE
Fix the empty space at the bottom of the page

### DIFF
--- a/ui/media/css/image-modal.css
+++ b/ui/media/css/image-modal.css
@@ -13,6 +13,10 @@
     z-index: 1001;
 }
 
+#viewFullSizeImgModal:not(.active) {
+    display: none;
+}
+
 #viewFullSizeImgModal > * {
     pointer-events: auto;
     margin: 0;


### PR DESCRIPTION
Inactive popups have `visibility: hidden`, and because the image modal has a 100vh height it causes a massive empty space at the bottom of the page