### PR TITLE
Fix the willReadFrequently warning on Chrome

### DIFF
--- a/ui/media/js/image-editor.js
+++ b/ui/media/js/image-editor.js
@@ -414,7 +414,7 @@ class ImageEditor {
 			this.layers[name] = {
 				name: name,
 				canvas: canvas,
-				ctx: canvas.getContext("2d")
+				ctx: canvas.getContext("2d", { willReadFrequently: true })
 			}
 		})
 


### PR DESCRIPTION
Fix this warning on Chrome when saving a drawing in the image editor:
![image](https://user-images.githubusercontent.com/48073125/227440036-283f5e06-7001-4396-ac92-33075d8b6613.png)

More info: https://stackoverflow.com/questions/74101155/chrome-warning-willreadfrequently-attribute-set-to-true