### PR TITLE
Fix for Clear button in image editor

### DIFF
--- a/ui/media/js/image-editor.js
+++ b/ui/media/js/image-editor.js
@@ -171,6 +171,7 @@ const IMAGE_EDITOR_ACTIONS = [
 		icon: "fa-solid fa-xmark",
 		handler: (editor) => {
 			editor.ctx_current.clearRect(0, 0, editor.width, editor.height)
+			imageEditor.setImage(null, editor.width, editor.height) // properly reset the drawing canvas
 		},
 		trackHistory: true
 	},


### PR DESCRIPTION
Repro steps:
From a fresh page, click 'Draw'. Image editor launches.
Draw something and hit 'Save'.
Click 'Draw' again, then click 'Clear'

Expected behavior:
The canvas is cleared.

Actual result:
The previous drawing remains there.

This is happening because during the Save process, the drawing is copied to the background canvas, but the latter is not properly cleared by the Clear button.