### PR TITLE
Moving attention weighting to InvokeAI syntax

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -130,7 +130,9 @@ function createModifierGroup(modifierGroup, initiallyExpanded, removeBy) {
 
 function trimModifiers(tag) {
     // Remove trailing '-' and/or '+'
-    return tag.replace(/[-+]+$/, '');
+    tag = tag.replace(/[-+]+$/, '');
+    // Remove parentheses at beginning and end
+    return tag.replace(/^[(]+|[\s)]+$/g, '');
 }
 
 async function loadModifiers() {

--- a/ui/plugins/ui/Modifiers-wheel.plugin.js
+++ b/ui/plugins/ui/Modifiers-wheel.plugin.js
@@ -1,5 +1,7 @@
 (function () {
     "use strict"
+
+    const MAX_WEIGHT = 5
     
     if (typeof editorModifierTagsList !== 'object') {
         console.error('editorModifierTagsList missing...')
@@ -36,19 +38,19 @@
                             break
                         }
                     }
-                    if (s.charAt(0) !== '(' && s.charAt(s.length-1) !== ')' && s.trim().includes(' ')) {
+                    if (s.charAt(0) !== '(' && s.charAt(s.length - 1) !== ')' && s.trim().includes(' ')) {
                         s = '(' + s + ')'
                         t = '(' + t + ')'
                     }
                     if (delta < 0) {
                         // wheel scrolling up
-                        if (s.substring(s.length-1) == '-') {
+                        if (s.substring(s.length - 1) == '-') {
                             s = s.substring(0, s.length - 1)
                             t = t.substring(0, t.length - 1)
                         }
                         else
                         {
-                            if (s.substring(s.length-5) !== '+'.repeat(5)) {
+                            if (s.substring(s.length - MAX_WEIGHT) !== '+'.repeat(MAX_WEIGHT)) {
                                 s = s + '+'
                                 t = t + '+'
                             }
@@ -56,19 +58,19 @@
                     }
                     else{
                         // wheel scrolling down
-                        if (s.substring(s.length-1) == '+') {
+                        if (s.substring(s.length - 1) == '+') {
                             s = s.substring(0, s.length - 1)
                             t = t.substring(0, t.length - 1)
                         }
                         else
                         {
-                            if (s.substring(s.length-5) !== '-'.repeat(5)) {
+                            if (s.substring(s.length - MAX_WEIGHT) !== '-'.repeat(MAX_WEIGHT)) {
                                 s = s + '-'
                                 t = t + '-'
                             }
                         }
                     }
-                    if (s.charAt(0) === '(' && s.charAt(s.length-1) === ')') {
+                    if (s.charAt(0) === '(' && s.charAt(s.length - 1) === ')') {
                         s = s.substring(1, s.length - 1)
                         t = t.substring(1, t.length - 1)
                     }

--- a/ui/plugins/ui/Modifiers-wheel.plugin.js
+++ b/ui/plugins/ui/Modifiers-wheel.plugin.js
@@ -36,29 +36,29 @@
                     }
                     if (delta < 0) {
                         // wheel scrolling up
-                        if (s.substring(0, 1) == '[' && s.substring(s.length-1) == ']') {
-                            s = s.substring(1, s.length - 1)
-                            t = t.substring(1, t.length - 1)
+                        if (s.substring(s.length-1) == '-') {
+                            s = s.substring(0, s.length - 1)
+                            t = t.substring(0, t.length - 1)
                         }
                         else
                         {
-                            if (s.substring(0, 10) !== '('.repeat(10) && s.substring(s.length-10) !== ')'.repeat(10)) {
-                                s = '(' + s + ')'
-                                t = '(' + t + ')'
+                            if (s.substring(s.length-5) !== '+'.repeat(5)) {
+                                s = s + '+'
+                                t = t + '+'
                             }
                         }
                     }
                     else{
                         // wheel scrolling down
-                        if (s.substring(0, 1) == '(' && s.substring(s.length-1) == ')') {
-                            s = s.substring(1, s.length - 1)
-                            t = t.substring(1, t.length - 1)
+                        if (s.substring(s.length-1) == '+') {
+                            s = s.substring(0, s.length - 1)
+                            t = t.substring(0, t.length - 1)
                         }
                         else
                         {
-                            if (s.substring(0, 10) !== '['.repeat(10) && s.substring(s.length-10) !== ']'.repeat(10)) {
-                                s = '[' + s + ']'
-                                t = '[' + t + ']'
+                            if (s.substring(s.length-5) !== '-'.repeat(5)) {
+                                s = s + '-'
+                                t = t + '-'
                             }
                         }
                     }

--- a/ui/plugins/ui/Modifiers-wheel.plugin.js
+++ b/ui/plugins/ui/Modifiers-wheel.plugin.js
@@ -1,4 +1,6 @@
-(function () { "use strict"
+(function () {
+    "use strict"
+    
     if (typeof editorModifierTagsList !== 'object') {
         console.error('editorModifierTagsList missing...')
         return
@@ -34,6 +36,10 @@
                             break
                         }
                     }
+                    if (s.charAt(0) !== '(' && s.charAt(s.length-1) !== ')' && s.trim().includes(' ')) {
+                        s = '(' + s + ')'
+                        t = '(' + t + ')'
+                    }
                     if (delta < 0) {
                         // wheel scrolling up
                         if (s.substring(s.length-1) == '-') {
@@ -61,6 +67,10 @@
                                 t = t + '-'
                             }
                         }
+                    }
+                    if (s.charAt(0) === '(' && s.charAt(s.length-1) === ')') {
+                        s = s.substring(1, s.length - 1)
+                        t = t.substring(1, t.length - 1)
                     }
                     i.parentElement.getElementsByClassName('modifier-card-label')[0].getElementsByTagName("p")[0].innerText = s
                     // update activeTags


### PR DESCRIPTION
() and [] were actually ignored by the legacy parser, so moving the Ctrl+Wheel shortcut to the InvokeAI syntax of '+' and '-'.