### PR TITLE
Fix tab bar when there's many plugin tabs

### DIFF
--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -309,8 +309,7 @@ div.img-preview img {
 #server-status {
     position: absolute;
     right: 16px;
-    top: 50%;
-    transform: translateY(-50%);
+    top: 4px;
     text-align: right;
 }
 #server-status-color {
@@ -336,6 +335,7 @@ div.img-preview img {
     position: relative;
     background: var(--background-color4);
     display: flex;
+    padding: 12px 0 0;
 }
 .tab .icon {
     padding-right: 4pt;
@@ -344,8 +344,7 @@ div.img-preview img {
 }
 #logo {
     display: inline;
-    padding: 12px;
-    padding-top: 8px;
+    padding: 0 12px 12px;
     white-space: nowrap;
 }
 #logo h1 {
@@ -881,9 +880,6 @@ input::file-selector-button {
     .tab .icon {
         padding-right: 0px;
     }
-    #server-status {
-        top: 75%;
-    }
     .popup > div {
         padding-left: 5px !important;
         padding-right: 5px !important;
@@ -1126,6 +1122,8 @@ input::file-selector-button {
 .tab-container {
     display: flex;
     align-items: flex-end;
+    overflow-x: auto;
+    overflow-y: hidden;
 }
 
 .tab {


### PR DESCRIPTION
This will move the status from being vertically centered to being fixed at the top of the page.

1800px current:
![image](https://user-images.githubusercontent.com/8977984/227691292-4e19b1a3-f5fa-4911-80c1-baec5e064b3d.png)
1800px with fix:
![image](https://user-images.githubusercontent.com/8977984/227691370-3da29c41-3ef7-43a7-822a-554d97da711c.png)

1280px current:
![image](https://user-images.githubusercontent.com/8977984/227691561-21082c67-08ba-4e11-bc73-cf3c43b2214e.png)
1280px with fix:
![image](https://user-images.githubusercontent.com/8977984/227691623-1ad3d257-7ff4-4877-a846-e56fb5160933.png)

720px current:
![image](https://user-images.githubusercontent.com/8977984/227691914-3e8ac571-6127-41d6-9cf8-ebf22ab59b38.png)
720px with fix:
![image](https://user-images.githubusercontent.com/8977984/227691970-d42a5cc2-ae78-4616-8301-da252a03ebab.png)

400px current:
![image](https://user-images.githubusercontent.com/8977984/227692093-48002b4e-a0e2-471a-b564-1091222f5e1a.png)
400px with fix:
![image](https://user-images.githubusercontent.com/8977984/227692162-12814415-b3d9-4602-abc5-d2f1ca2e30d5.png)

