### PR TITLE
Fix restoration of disabled image tags

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -157,7 +157,7 @@ async function loadModifiers() {
     document.dispatchEvent(new Event('loadImageModifiers'))
 }
 
-function refreshModifiersState(newTags) {
+function refreshModifiersState(newTags, inactiveTags) {
     // clear existing modifiers
     document.querySelector('#editor-modifiers').querySelectorAll('.modifier-card').forEach(modifierCard => {
         const modifierName = modifierCard.querySelector('.modifier-card-label p').dataset.fullName // pick the full modifier name
@@ -211,7 +211,7 @@ function refreshModifiersState(newTags) {
             })
         }
     })
-    refreshTagsList()
+    refreshTagsList(inactiveTags)
 }
 
 function refreshInactiveTags(inactiveTags) {
@@ -228,13 +228,13 @@ function refreshInactiveTags(inactiveTags) {
     let overlays = document.querySelector('#editor-inputs-tags-list').querySelectorAll('.modifier-card-overlay')
     overlays.forEach (i => {
         let modifierName = i.parentElement.getElementsByClassName('modifier-card-label')[0].getElementsByTagName("p")[0].innerText
-        if (inactiveTags.find(element => element === modifierName) !== undefined) {
+        if (inactiveTags?.find(element => element === modifierName) !== undefined) {
             i.parentElement.classList.add('modifier-toggle-inactive')
         }
     })
 }
 
-function refreshTagsList() {
+function refreshTagsList(inactiveTags) {
     editorModifierTagsList.innerHTML = ''
 
     if (activeTags.length == 0) {
@@ -266,6 +266,7 @@ function refreshTagsList() {
     let brk = document.createElement('br')
     brk.style.clear = 'both'
     editorModifierTagsList.appendChild(brk)
+    refreshInactiveTags(inactiveTags)
     document.dispatchEvent(new Event('refreshImageModifiers')) // notify plugins that the image tags have been refreshed 
 }
 


### PR DESCRIPTION
Fixes a regression introduced by PR 1003 that causes _disabled_ image tags to be restored in an _enabled_ state by the "image modifiers improvements" plugin. No change to the regular UI.