### PR TITLE
Fire event when random seed is toggled by dnd.js

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -92,11 +92,13 @@ const TASK_MAPPING = {
         setUI: (seed) => {
             if (!seed) {
                 randomSeedField.checked = true
+                randomSeedField.dispatchEvent(new Event('change')) // let plugins know that the state of the random seed toggle changed
                 seedField.disabled = true
                 seedField.value = 0
                 return
             }
             randomSeedField.checked = false
+            randomSeedField.dispatchEvent(new Event('change')) // let plugins know that the state of the random seed toggle changed
             seedField.disabled = false
             seedField.value = seed
         },

--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -92,7 +92,6 @@ const TASK_MAPPING = {
         setUI: (seed) => {
             if (!seed) {
                 randomSeedField.checked = true
-                randomSeedField.dispatchEvent(new Event('change')) // let plugins know that the state of the random seed toggle changed
                 seedField.disabled = true
                 seedField.value = 0
                 return


### PR DESCRIPTION
This is to let plugins know that the state of the random seed toggle was programmatically changed by dnd.js. No change for regular UI.