### PR TITLE
Reworked the task entry config section

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 Our focus continues to remain on an easy installation experience, and an easy user-interface. While still remaining pretty powerful, in terms of features and speed.
 
 ### Detailed changelog
+* 2.5.27 - 27 Mar 2023 - Add containers to task entry config for easier targeting with selectors, helpful especially for plugins. Update `CONTRIBUTING.md` to remove outdated reference to react.
 * 2.5.26 - 15 Mar 2023 - Allow styling the buttons displayed on an image. Update the API to allow multiple buttons and text labels in a single row. Thanks @ogmaresca.
 * 2.5.26 - 15 Mar 2023 - View images in full-screen, by either clicking on the image, or clicking the "Full screen" icon next to the Seed number on the image. Thanks @ogmaresca for the internal API.
 * 2.5.25 - 14 Mar 2023 - Button to download all the images, and all the metadata as a zip file. This is available at the top of the UI, as well as on each image. Thanks @JeLuf.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,6 @@ or for Windows
 10) Congrats, now any changes you make in your repo `ui` folder are linked to this running archive of the app and can be previewed in the browser.
 11) Please update CHANGES.md in your pull requests.
 
-Check the `ui/frontend/build/README.md` for instructions on running and building the React code.
-
 ## Development environment for Installer changes
 Build the Windows installer using Windows, and the Linux installer using Linux. Don't mix the two, and don't use WSL. An Ubuntu VM is fine for building the Linux installer on a Windows host.
 

--- a/ui/easydiffusion/utils/save_utils.py
+++ b/ui/easydiffusion/utils/save_utils.py
@@ -1,11 +1,11 @@
 import os
 import time
-import base64
 import re
 
 from easydiffusion.types import TaskData, GenerateImageRequest
 
 from sdkit.utils import save_images, save_dicts
+from numpy import base_repr
 
 filename_regex = re.compile("[^a-zA-Z0-9._-]")
 
@@ -121,8 +121,7 @@ def make_filename_callback(req: GenerateImageRequest, suffix=None, now=None):
         now = time.time()
 
     def make_filename(i):
-        img_id = base64.b64encode(int(now + i).to_bytes(8, "big")).decode()  # Generate unique ID based on time.
-        img_id = img_id.translate({43: None, 47: None, 61: None})[-8:]  # Remove + / = and keep last 8 chars.
+        img_id = base_repr(int(now * 10000), 36)[-7:] + base_repr(int(i),36)  # Base 36 conversion, 0-9, A-Z
 
         prompt_flattened = filename_regex.sub("_", req.prompt)[:50]
         name = f"{prompt_flattened}_{img_id}"

--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -574,6 +574,11 @@ div.img-preview img {
     margin-bottom: 5pt;
     margin-top: 5pt;
 }
+
+.taskConfigContainer {
+    display: inline;
+}
+
 .img-batch {
     display: inline;
 }

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -904,36 +904,46 @@ function onTaskEntryDragOver(event) {
 
 function createTask(task) {
     let taskConfig = ''
+    let taskConfigList = [];
 
     if (task.reqBody.init_image !== undefined) {
         let h = 80
         let w = task.reqBody.width * h / task.reqBody.height >>0
         taskConfig += `<div class="task-initimg" style="float:left;"><img style="width:${w}px;height:${h}px;" src="${task.reqBody.init_image}"><div class="task-fs-initimage"></div></div>`
     }
-    taskConfig += `<b>Seed:</b> ${task.seed}, <b>Sampler:</b> ${task.reqBody.sampler_name}, <b>Inference Steps:</b> ${task.reqBody.num_inference_steps}, <b>Guidance Scale:</b> ${task.reqBody.guidance_scale}, <b>Model:</b> ${task.reqBody.use_stable_diffusion_model}`
+    
+    // Tags are left intentionally not closed so a call to .join('</span>,</div>`) handle all the commas correctly
+    taskConfigList.push(`<div class="taskConfigContainer taskSeedContainer"><b>Seed:</b> <span class="taskSeed">${task.seed}`)
+    taskConfigList.push(`<div class="taskConfigContainer taskSamplerContainer"><b>Sampler:</b> <span class="taskSampler">${task.reqBody.sampler_name}`)
+    taskConfigList.push(`<div class="taskConfigContainer taskInferenceStepsContainer"><b>Inference Steps:</b> <span class="taskInferenceSteps">${task.reqBody.num_inference_steps}`)
+    taskConfigList.push(`<div class="taskConfigContainer taskGuidanceScaleContainer"><b>Guidance Scale:</b> <span class="taskGuidanceScale">${task.reqBody.guidance_scale}`)
+    taskConfigList.push(`<div class="taskConfigContainer taskModelContainer"><b>Model:</b> <span class="taskModel">${task.reqBody.use_stable_diffusion_model}`)
 
     if (task.reqBody.use_vae_model.trim() !== '') {
-        taskConfig += `, <b>VAE:</b> ${task.reqBody.use_vae_model}`
+        taskConfigList.push(`<div class="taskConfigContainer taskVAEContainer"><b>VAE:</b> <span class="taskVAE">${task.reqBody.use_vae_model}`)
     }
     if (task.reqBody.negative_prompt.trim() !== '') {
-        taskConfig += `, <b>Negative Prompt:</b> ${task.reqBody.negative_prompt}`
+        taskConfigList.push(`<div class="taskConfigContainer taskNegativePromptContainer"><b>Negative Prompt:</b> <span class="taskNegativePrompt">${task.reqBody.negative_prompt}`)
     }
     if (task.reqBody.init_image !== undefined) {
-        taskConfig += `, <b>Prompt Strength:</b> ${task.reqBody.prompt_strength}`
+        taskConfigList.push(`<div class="taskConfigContainer taskPromptStrengthContainer"><b>Prompt Strength:</b> <span class="taskPromptStrength">${task.reqBody.prompt_strength}`)
     }
     if (task.reqBody.use_face_correction) {
-        taskConfig += `, <b>Fix Faces:</b> ${task.reqBody.use_face_correction}`
+        taskConfigList.push(`<div class="taskConfigContainer taskFaceCorrectionContainer"><b>Fix Faces:</b> <span class="taskFaceCorrection">${task.reqBody.use_face_correction}`)
     }
     if (task.reqBody.use_upscale) {
-        taskConfig += `, <b>Upscale:</b> ${task.reqBody.use_upscale} (${task.reqBody.upscale_amount || 4}x)`
+        taskConfigList.push(`<div class="taskConfigContainer taskUpscaleContainer"><b>Upscale:</b> <span class="taskUpscale">${task.reqBody.use_upscale} (${task.reqBody.upscale_amount || 4}x)`)
     }
     if (task.reqBody.use_hypernetwork_model) {
-        taskConfig += `, <b>Hypernetwork:</b> ${task.reqBody.use_hypernetwork_model}`
-        taskConfig += `, <b>Hypernetwork Strength:</b> ${task.reqBody.hypernetwork_strength}`
+        taskConfigList.push(`<div class="taskConfigContainer taskHypernetworkContainer"><b>Hypernetwork:</b> <span class="taskHypernetwork">${task.reqBody.use_hypernetwork_model}`)
+        taskConfigList.push(`<div class="taskConfigContainer taskHypernetworkStrengthContainer"><b>Hypernetwork Strength:</b> <span class="taskHypernetworkStrength">${task.reqBody.hypernetwork_strength}`)
     }
     if (task.reqBody.preserve_init_image_color_profile) {
-        taskConfig += `, <b>Preserve Color Profile:</b> true`
+        taskConfigList.push(`<div class="taskConfigContainer taskPreserveColorContainer"><b>Preserve Color Profile:</b> <span class="taskPreserveColor">true `)
     }
+    // Join with closing tags + add final closing tag with no comma
+    taskConfig += `<div class="taskConfigData">${taskConfigList.join('</span>,&nbsp;</div>')}</span></div></div>`;
+
 
     let taskEntry = document.createElement('div')
     taskEntry.id = `imageTaskContainer-${Date.now()}`


### PR DESCRIPTION
I was trying to make a simple plugin to allow you to customize what shows up on this section and realized it was going to be pretty difficult with how it's set up now. This change just adds some divs and spans to the configs so it's easier to do stuff with them in the dom. I also changed how it's built to make adding the commas more consistent.

The visual outcome is exactly the same as before, but the HTML structure is more useful:
![Screenshot 2023-03-27 150348](https://user-images.githubusercontent.com/1221253/228043764-65e33d05-e4b7-455b-928d-8318affee6ae.png)
(long negative prompts for reference)

Also removed a misleading line from the docs.