### PR TITLE
Automatic AMD GPU detection on Linux

### DIFF
--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -73,11 +73,11 @@ DGPU_BRAND=$(lspci 2>/dev/null | grep Display)
 if python ../scripts/check_modules.py torch torchvision; then
     # temp fix for installations that installed torch 2.0 by mistake
     if [ "$OS_NAME" == "linux" ]; then
-        # Check for AMD dGPU first, assume nobody has a primary nvidia GPU and AMD secondary GPU,
-        # and if they do they can edit this themselves like AMD users already have to
-        if echo "$DGPU_BRAND" | grep -q "AMD"; then
-            python -m pip install --upgrade torch torchvision --extra-index-url "https://download.pytorch.org/whl/rocm5.4.2" -q
-        elif echo "$GPU_BRAND" | grep -q "AMD"; then
+        # Check for AMD and NVIDIA dGPUs, always preferring an NVIDIA GPU if available
+        # Fall back to NVIDA/CUDA if somehow none of these checks pass
+        if echo "$DGPU_BRAND" | grep -q "NVIDIA" || echo "$GPU_BRAND" | grep -q "NVIDIA"; then
+            python -m pip install --upgrade torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116 -q
+        elif echo "$DGPU_BRAND" | grep -q "AMD" || echo "$GPU_BRAND" | grep -q "AMD"; then
             python -m pip install --upgrade torch torchvision --extra-index-url "https://download.pytorch.org/whl/rocm5.4.2" -q
         else
             python -m pip install --upgrade torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116 -q
@@ -94,11 +94,11 @@ else
     export PYTHONPATH="$INSTALL_ENV_DIR/lib/python3.8/site-packages"
 
     if [ "$OS_NAME" == "linux" ]; then
-        # Check for AMD dGPU first, assume nobody has a primary nvidia GPU and AMD secondary GPU,
-        # and if they do they can edit this themselves like AMD users already have to
-        if echo "$DGPU_BRAND" | grep -q "AMD"; then
-            python -m pip install --upgrade torch torchvision --extra-index-url "https://download.pytorch.org/whl/rocm5.4.2" || fail "Installation of torch and torchvision for ROCm failed"
-        elif echo "$GPU_BRAND" | grep -q "AMD"; then
+        # Check for AMD and NVIDIA dGPUs, always preferring an NVIDIA GPU if available
+        # Fall back to NVIDA/CUDA if somehow none of these checks pass
+        if echo "$DGPU_BRAND" | grep -q "NVIDIA" || echo "$GPU_BRAND" | grep -q "NVIDIA"; then
+            python -m pip install --upgrade torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116 || fail "Installation of torch and torchvision for CUDA failed"
+        elif echo "$DGPU_BRAND" | grep -q "AMD" || echo "$GPU_BRAND" | grep -q "AMD"; then
             python -m pip install --upgrade torch torchvision --extra-index-url "https://download.pytorch.org/whl/rocm5.4.2" || fail "Installation of torch and torchvision for ROCm failed"
         else
             python -m pip install --upgrade torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116 || fail "Installation of torch and torchvision for CUDA failed"

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -97,18 +97,13 @@ else
         # Check for AMD dGPU first, assume nobody has a primary nvidia GPU and AMD secondary GPU,
         # and if they do they can edit this themselves like AMD users already have to
         if echo "$DGPU_BRAND" | grep -q "AMD"; then
-            installed=$(python -m pip install --upgrade torch torchvision --extra-index-url "https://download.pytorch.org/whl/rocm5.4.2")
+            python -m pip install --upgrade torch torchvision --extra-index-url "https://download.pytorch.org/whl/rocm5.4.2" || fail "Installation of torch and torchvision for ROCm failed"
         elif echo "$GPU_BRAND" | grep -q "AMD"; then
-            installed=$(python -m pip install --upgrade torch torchvision --extra-index-url "https://download.pytorch.org/whl/rocm5.4.2")
+            python -m pip install --upgrade torch torchvision --extra-index-url "https://download.pytorch.org/whl/rocm5.4.2" || fail "Installation of torch and torchvision for ROCm failed"
         else
-            installed=$(python -m pip install --upgrade torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116)
+            python -m pip install --upgrade torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116 || fail "Installation of torch and torchvision for CUDA failed"
         fi
-        
-        if [ -n "$installed" ]; then
-            echo "Installed."
-        else
-            fail "torch install failed"
-        fi
+        echo "Installed."
     elif [ "$OS_NAME" == "macos" ]; then
         if python -m pip install --upgrade torch==1.13.1 torchvision==0.14.1 ; then
             echo "Installed."

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -83,9 +83,9 @@ if python ../scripts/check_modules.py torch torchvision; then
     if [ "$OS_NAME" == "linux" ]; then
         # Check for AMD and NVIDIA dGPUs, always preferring an NVIDIA GPU if available
         if [ "$HAS_NVIDIA" != "yes" -a "$HAS_AMD" = "yes" ]; then
-            python -m pip install --upgrade torch torchvision --extra-index-url "https://download.pytorch.org/whl/rocm5.4.2"  || fail "Installation of torch and torchvision for AMD failed"
+            python -m pip install --upgrade torch torchvision --extra-index-url "https://download.pytorch.org/whl/rocm5.4.2" -q || fail "Installation of torch and torchvision for AMD failed"
         else
-            python -m pip install --upgrade torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url "https://download.pytorch.org/whl/cu116"  || fail "Installation of torch and torchvision for CUDA failed"
+            python -m pip install --upgrade torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url "https://download.pytorch.org/whl/cu116" -q || fail "Installation of torch and torchvision for CUDA failed"
         fi
     elif [ "$OS_NAME" == "macos" ]; then
         python -m pip install --upgrade torch==1.13.1 torchvision==0.14.1 -q

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -82,7 +82,7 @@ if python ../scripts/check_modules.py torch torchvision; then
     # temp fix for installations that installed torch 2.0 by mistake
     if [ "$OS_NAME" == "linux" ]; then
         # Check for AMD and NVIDIA dGPUs, always preferring an NVIDIA GPU if available
-        if [ "$HAS_NVIDIA" -ne "yes" -a "$HAS_AMD" -eq "yes" ]; then
+        if [ "$HAS_NVIDIA" != "yes" -a "$HAS_AMD" = "yes" ]; then
             python -m pip install --upgrade torch torchvision --extra-index-url "https://download.pytorch.org/whl/rocm5.4.2"  || fail "Installation of torch and torchvision for AMD failed"
         else
             python -m pip install --upgrade torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url "https://download.pytorch.org/whl/cu116"  || fail "Installation of torch and torchvision for CUDA failed"
@@ -100,7 +100,7 @@ else
 
     if [ "$OS_NAME" == "linux" ]; then
         # Check for AMD and NVIDIA dGPUs, always preferring an NVIDIA GPU if available
-        if [ "$HAS_NVIDIA" -ne "yes" -a "$HAS_AMD" -eq "yes" ]; then
+        if [ "$HAS_NVIDIA" != "yes" -a "$HAS_AMD" = "yes" ]; then
             python -m pip install --upgrade torch torchvision --extra-index-url "https://download.pytorch.org/whl/rocm5.4.2"  || fail "Installation of torch and torchvision for ROCm failed"
         else
             python -m pip install --upgrade torch==1.13.1+cu116 torchvision==0.14.1+cu116 --extra-index-url "https://download.pytorch.org/whl/cu116" || fail "Installation of torch and torchvision for CUDA failed"


### PR DESCRIPTION
Automatically detects AMD GPUs and installs the ROCm version of PyTorch instead of the cuda one

A later improvement may be to detect the GPU ROCm version and handle GPUs that dont work on upstream ROCm, ether because they're too old and need a special patched version, or too new and need `HSA_OVERRIDE_GFX_VERSION=10.3.0` added, possibly check through `rocminfo`?

For AMD this uses the current latest ROCm version of 5.4.2, and PyTorch 2.0 which is only 2.0 because they felt like it and is basically 1.14 and is entirely backwards compatible, per [their FAQ](https://pytorch.org/get-started/pytorch-2.0/#faqs)

nvidia/cuda is unchanged

----

This was tested and working on a up to date as of this comment Arch Linux system, with ROCm installed according to <https://wiki.archlinux.org/title/GPGPU#ROCm>, with a AMD RX 6800M, GFX1031, with `HSA_OVERRIDE_GFX_VERSION=10.3.0` hard-coded locally.