### PR TITLE
reworked how task config is setup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 Our focus continues to remain on an easy installation experience, and an easy user-interface. While still remaining pretty powerful, in terms of features and speed.
 
 ### Detailed changelog
+* 2.5.30 - 28 Mar 2023 - Refactor task entry config to use a generating method. Added ability for plugins to easily add to this. Removed confusing sentence from `contributing.md`
 * 2.5.30 - 28 Mar 2023 - Allow the user to undo the deletion of tasks or images, instead of showing a pop-up each time. The new `Undo` button will be present at the top of the UI. Thanks @JeLuf.
 * 2.5.30 - 28 Mar 2023 - Support saving lossless WEBP images. Thanks @ogmaresca.
 * 2.5.30 - 28 Mar 2023 - Lots of bug fixes for the UI (Read LoRA flag in metadata files, new prompt weight format with scrollwheel, fix overflow with lots of tabs, clear button in image editor, shorter filenames in download). Thanks @patriceac, @JeLuf and @ogmaresca.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,6 @@ or for Windows
 10) Congrats, now any changes you make in your repo `ui` folder are linked to this running archive of the app and can be previewed in the browser.
 11) Please update CHANGES.md in your pull requests.
 
-Check the `ui/frontend/build/README.md` for instructions on running and building the React code.
-
 ## Development environment for Installer changes
 Build the Windows installer using Windows, and the Linux installer using Linux. Don't mix the two, and don't use WSL. An Ubuntu VM is fine for building the Linux installer on a Windows host.
 

--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -572,6 +572,11 @@ div.img-preview img {
     margin-bottom: 5pt;
     margin-top: 5pt;
 }
+
+.taskConfigContainer {
+    display: inline;
+}
+
 .img-batch {
     display: inline;
 }


### PR DESCRIPTION
Did what @cmdr2 requested and made this not a setting. As a bonus, I added a simple way for plugins to add/modify whatever they want here. A plugin simply adds a key to `taskConfigSetup.pluginTaskConfig`. If this key matches one in the task config, it overwrites it, so you can hide things easily. 

Example: the reason I did any of this in the first place was to hide negative prompt. My plugin is just: `taskConfigSetup.pluginTaskConfig['negative_prompt'] = { label: 'Negative Prompt', visible: () => false }` 

With the value getter, plugins can easily add anything from the task:
`taskConfigSetup.pluginTaskConfig['my_custom_task_config'] = { label: 'Custom', value: (task) => { // get and return value } }`