### PR TITLE
Persistentish user configuration

### DIFF
--- a/scripts/on_env_start.bat
+++ b/scripts/on_env_start.bat
@@ -8,6 +8,10 @@ if exist "scripts\config.bat" (
     @call scripts\config.bat
 )
 
+if exist "scripts\user_config.bat" (
+    @call scripts\user_config.bat
+)
+
 if "%update_branch%"=="" (
     set update_branch=main
 )

--- a/scripts/on_env_start.sh
+++ b/scripts/on_env_start.sh
@@ -8,6 +8,11 @@ if [ -f "scripts/config.sh" ]; then
     source scripts/config.sh
 fi
 
+if [ -f "scripts/user_config.sh" ]; then
+    source scripts/user_config.sh
+fi
+
+
 if [ "$update_branch" == "" ]; then
     export update_branch="main"
 fi


### PR DESCRIPTION
This adds support for a `user_config.(sh|bat)` script thats called after confg.sh, to be used to set custom environment options

For example, this script can persistently override `update_branch`, or locally set environment variables at runtime for advanced AMD GPU usage, such as `HSA_OVERRIDE_GFX_VERSION` or `ROCR_VISIBLE_DEVICES`, or to set stuff like `XDG_CACHE_HOME` so that all the large model downloads are persisted.

Unlike the existing `config` scripts, these wont be overwritten