### PR TITLE
Add back/forward buttons to switch between images in tasks

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -398,7 +398,30 @@ function showImages(reqBody, res, outputContainer, livePreview) {
         if ('seed' in result && !imageElem.hasAttribute('data-seed')) {
             const imageExpandBtn = imageItemElem.querySelector('.imgExpandBtn')
             imageExpandBtn.addEventListener('click', function() {
-                imageModal(imageElem.src)
+                function previousImage(img) {
+                    const allImages = Array.from(outputContainer.parentNode.querySelectorAll('.imgItem img'))
+                    const index = allImages.indexOf(img)
+                    return allImages.slice(0, index).reverse()[0]
+                }
+
+                function nextImage(img) {
+                    const allImages = Array.from(outputContainer.parentNode.querySelectorAll('.imgItem img'))
+                    const index = allImages.indexOf(img)
+                    return allImages.slice(index + 1)[0]
+                }
+
+                function imageModalParameter(img) {
+                    const previousImg = previousImage(img)
+                    const nextImg = nextImage(img)
+
+                    return {
+                        src: img.src,
+                        previous: previousImg ? () => imageModalParameter(previousImg) : undefined,
+                        next: nextImg ? () => imageModalParameter(nextImg) : undefined,
+                    }
+                }
+
+                imageModal(imageModalParameter(imageElem))
             })
 
             const req = Object.assign({}, reqBody, {


### PR DESCRIPTION
Adds back/forward buttons in the image modal, if there is a previous or next image. The arrow keys also function as the arrow buttons.