### PR TITLE
Don't paste empty prompts

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -608,7 +608,7 @@ document.addEventListener('paste', async (event) => {
     }
     const paste = (event.clipboardData || window.clipboardData).getData('text')
     const selection = window.getSelection()
-    if (selection.toString().trim().length <= 0 && await parseContent(paste)) {
+    if (paste != "" && selection.toString().trim().length <= 0 && await parseContent(paste)) {
         event.preventDefault()
         return
     }


### PR DESCRIPTION
When pasting e.g. an image, window.clipboardData).getData('text') returns an empty string, which would delete the prompt. 

https://discord.com/channels/1014774730907209781/1093186485563424838