### PR TITLE
Properly reset LoRA selection from Use Settings

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -350,7 +350,7 @@ function restoreTaskToUI(task, fieldsToSkip) {
     }
     
     if (!('use_lora_model' in task.reqBody)) {
-        loraModelField.value = "None"
+        loraModelField.value = ""
         loraModelField.dispatchEvent(new Event("change"))
     }
     


### PR DESCRIPTION
Repro steps: create a task with LoRA dropdown set to None, and a second task with a LoRA selected. Then click on Use Settings from the first task.

Expected result: LoRA set to None.
Actual result: LoRA remains unchanged (as selected from second task).
