### PR TITLE
Fix the tooltip display for long modifiers

### DIFF
--- a/ui/media/css/modifier-thumbnails.css
+++ b/ui/media/css/modifier-thumbnails.css
@@ -153,6 +153,10 @@
     position: absolute;
     z-index: 3;
 }
+.modifier-card-overlay:hover ~ .modifier-card-container .modifier-card-label.tooltip .tooltip-text {
+    visibility: visible;
+    opacity: 1;
+}
 .modifier-card:hover > .modifier-card-image-container .modifier-card-image-overlay {
     opacity: 1;
 }


### PR DESCRIPTION
Fixes this: https://discord.com/channels/1014774730907209781/1052771989426814986/1094641806194528266

After checking, this impacts every user, not just people using my plugin, so I think the fix should go in core for everyone to benefit from it.