### PR TITLE
Fix the styling of disabled image modifiers

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -230,7 +230,7 @@ function refreshInactiveTags(inactiveTags) {
     // update cards
     let overlays = document.querySelector('#editor-inputs-tags-list').querySelectorAll('.modifier-card-overlay')
     overlays.forEach (i => {
-        let modifierName = i.parentElement.getElementsByClassName('modifier-card-label')[0].getElementsByTagName("p")[0].innerText
+        let modifierName = i.parentElement.getElementsByClassName('modifier-card-label')[0].getElementsByTagName("p")[0].dataset.fullName
         if (inactiveTags?.find(element => element === modifierName) !== undefined) {
             i.parentElement.classList.add('modifier-toggle-inactive')
         }


### PR DESCRIPTION
Long custom modifiers in a disabled state (e.g. right-click on the image tag) are properly restored as disabled but are incorrectly shown as "active" in the UI. I somehow missed that in https://github.com/cmdr2/stable-diffusion-ui/pull/1062, so here is the fix for that. This change only applies to plugins that try to restore image modifiers, no change to the regular UI.