### PR TITLE
Don't scan safetensors files in load_default_models()

### DIFF
--- a/ui/easydiffusion/model_manager.py
+++ b/ui/easydiffusion/model_manager.py
@@ -44,7 +44,7 @@ def load_default_models(context: Context):
             load_model(
                 context,
                 model_type,
-                scan_model = context.model_paths[model_type] != None and not context.model_paths[model_type].endswith('safetensors')
+                scan_model = context.model_paths[model_type] != None and not context.model_paths[model_type].endswith('.safetensors')
             )
         except Exception as e:
             log.error(f"[red]Error while loading {model_type} model: {context.model_paths[model_type]}[/red]")

--- a/ui/easydiffusion/model_manager.py
+++ b/ui/easydiffusion/model_manager.py
@@ -41,11 +41,10 @@ def load_default_models(context: Context):
     for model_type in MODELS_TO_LOAD_ON_START:
         context.model_paths[model_type] = resolve_model_to_use(model_type=model_type)
         try:
-            load_model(context, model_type)
+            load_model(context, model_type, scan_model = not context.model_paths[model_type].endswith('safetensors'))
         except Exception as e:
             log.error(f"[red]Error while loading {model_type} model: {context.model_paths[model_type]}[/red]")
             log.error(f"[red]Error: {e}[/red]")
-            log.error(f"[red]Consider removing the model from the model folder.[red]")
 
 
 def unload_all(context: Context):

--- a/ui/easydiffusion/model_manager.py
+++ b/ui/easydiffusion/model_manager.py
@@ -41,7 +41,11 @@ def load_default_models(context: Context):
     for model_type in MODELS_TO_LOAD_ON_START:
         context.model_paths[model_type] = resolve_model_to_use(model_type=model_type)
         try:
-            load_model(context, model_type, scan_model = not context.model_paths[model_type].endswith('safetensors'))
+            load_model(
+                context,
+                model_type,
+                scan_model = context.model_paths[model_type] != None and not context.model_paths[model_type].endswith('safetensors')
+            )
         except Exception as e:
             log.error(f"[red]Error while loading {model_type} model: {context.model_paths[model_type]}[/red]")
             log.error(f"[red]Error: {e}[/red]")


### PR DESCRIPTION
`is_malicious_file()` already skips the scanning of safetensors files.
This PR adds a similar check to `load_default_models()`, so that no messages like 

```
ERROR: parsing pickle in [...] at position 0, opcode b'\xcd' unknown
```

are logged any more.

https://discord.com/channels/1014774730907209781/1095087265916657695/1095236389290917898