### PR TITLE
Don't save model_path if initial load fails

### DIFF
--- a/ui/easydiffusion/model_manager.py
+++ b/ui/easydiffusion/model_manager.py
@@ -49,6 +49,7 @@ def load_default_models(context: Context):
         except Exception as e:
             log.error(f"[red]Error while loading {model_type} model: {context.model_paths[model_type]}[/red]")
             log.exception(e)
+            del context.model_paths[model_type]
 
 def unload_all(context: Context):
     for model_type in KNOWN_MODEL_TYPES:


### PR DESCRIPTION
Fixes #882

If the load of the model fails during the initialization, an attempt to render an image using the same model fails because ED doesn't notice that the model has to be loaded. This PR ensures that the model is being reloaded if the initial load fails. If the second load attempt fails as well, the user will get a more helpful error message than 'model not loaded yet'.