### PR TITLE
Don't download 1.4 if other models are available

### DIFF
--- a/scripts/on_sd_start.bat
+++ b/scripts/on_sd_start.bat
@@ -186,22 +186,24 @@ call WHERE uvicorn > .tmp
     )
 )
 
-@if not exist "..\models\stable-diffusion\sd-v1-4.ckpt" (
-    @echo. & echo "Downloading data files (weights) for Stable Diffusion.." & echo.
+@if not exist "..\models\stable-diffusion\*.ckpt" (
+    @if not exist "..\models\stable-diffusion\*.safetensors" (
+        @echo. & echo "Downloading data files (weights) for Stable Diffusion.." & echo.
 
-    @call curl -L -k https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt > ..\models\stable-diffusion\sd-v1-4.ckpt
+        @call curl -L -k https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt > ..\models\stable-diffusion\sd-v1-4.ckpt
 
-    @if exist "..\models\stable-diffusion\sd-v1-4.ckpt" (
-        for %%I in ("..\models\stable-diffusion\sd-v1-4.ckpt") do if "%%~zI" NEQ "4265380512" (
-            echo. & echo "Error: The downloaded model file was invalid! Bytes downloaded: %%~zI" & echo.
-            echo. & echo "Error downloading the data files (weights) for Stable Diffusion. Sorry about that, please try to:" & echo "  1. Run this installer again." & echo "  2. If that doesn't fix it, please try the common troubleshooting steps at https://github.com/cmdr2/stable-diffusion-ui/wiki/Troubleshooting" & echo "  3. If those steps don't help, please copy *all* the error messages in this window, and ask the community at https://discord.com/invite/u9yhsFmEkB" & echo "  4. If that doesn't solve the problem, please file an issue at https://github.com/cmdr2/stable-diffusion-ui/issues" & echo "Thanks!" & echo.
+        @if exist "..\models\stable-diffusion\sd-v1-4.ckpt" (
+            for %%I in ("..\models\stable-diffusion\sd-v1-4.ckpt") do if "%%~zI" NEQ "4265380512" (
+                echo. & echo "Error: The downloaded model file was invalid! Bytes downloaded: %%~zI" & echo.
+                echo. & echo "Error downloading the data files (weights) for Stable Diffusion. Sorry about that, please try to:" & echo "  1. Run this installer again." & echo "  2. If that doesn't fix it, please try the common troubleshooting steps at https://github.com/cmdr2/stable-diffusion-ui/wiki/Troubleshooting" & echo "  3. If those steps don't help, please copy *all* the error messages in this window, and ask the community at https://discord.com/invite/u9yhsFmEkB" & echo "  4. If that doesn't solve the problem, please file an issue at https://github.com/cmdr2/stable-diffusion-ui/issues" & echo "Thanks!" & echo.
+                pause
+                exit /b
+            )
+        ) else (
+            @echo. & echo "Error downloading the data files (weights) for Stable Diffusion. Sorry about that, please try to:" & echo "  1. Run this installer again." & echo "  2. If that doesn't fix it, please try the common troubleshooting steps at https://github.com/cmdr2/stable-diffusion-ui/wiki/Troubleshooting" & echo "  3. If those steps don't help, please copy *all* the error messages in this window, and ask the community at https://discord.com/invite/u9yhsFmEkB" & echo "  4. If that doesn't solve the problem, please file an issue at https://github.com/cmdr2/stable-diffusion-ui/issues" & echo "Thanks!" & echo.
             pause
             exit /b
         )
-    ) else (
-        @echo. & echo "Error downloading the data files (weights) for Stable Diffusion. Sorry about that, please try to:" & echo "  1. Run this installer again." & echo "  2. If that doesn't fix it, please try the common troubleshooting steps at https://github.com/cmdr2/stable-diffusion-ui/wiki/Troubleshooting" & echo "  3. If those steps don't help, please copy *all* the error messages in this window, and ask the community at https://discord.com/invite/u9yhsFmEkB" & echo "  4. If that doesn't solve the problem, please file an issue at https://github.com/cmdr2/stable-diffusion-ui/issues" & echo "Thanks!" & echo.
-        pause
-        exit /b
     )
 )
 

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -170,8 +170,11 @@ if [ -f "../models/stable-diffusion/sd-v1-4.ckpt" ]; then
     fi
 fi
 
-if [ ! -f "../models/stable-diffusion/sd-v1-4.ckpt" ]; then
-    echo "Downloading data files (weights) for Stable Diffusion.."
+
+if find "../models/stable-diffusion/" -name "*.ckpt" -or -name "*.safetensors" > /dev/null; then
+    echo "Found existing model file(s)."
+else
+    echo "Downloading data files (weights) for Stable Diffusion..."
 
     curl -L -k https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt > ../models/stable-diffusion/sd-v1-4.ckpt
 


### PR DESCRIPTION
On Linux, the check is recursively. On Windows, it only checks for files in `models\stable-diffusion`, not in the subdirectories.

If the 1.4 model file _does_ exist, it will still check the size.