### PR TITLE
Don't write config.bat and config.sh any more

### DIFF
--- a/scripts/get_config.py
+++ b/scripts/get_config.py
@@ -1,0 +1,45 @@
+import os
+import argparse
+
+# The config file is in the same directory as this script
+config_directory = os.path.dirname(__file__)
+config_yaml = os.path.join(config_directory, "config.yaml")
+config_json = os.path.join(config_directory, "config.json")
+
+parser = argparse.ArgumentParser(description='Get values from config file')
+parser.add_argument('--default', dest='default', action='store',
+                     help='default value, to be used if the setting is not defined in the config file')
+parser.add_argument('key', metavar='key', nargs='+',
+                    help='config key to return')
+
+args = parser.parse_args()
+
+
+if os.path.isfile(config_yaml):
+    import yaml
+    with open(config_yaml, 'r') as configfile:
+        try:
+            config = yaml.safe_load(configfile)
+        except Exception as e:
+            print(e)
+            exit()
+elif os.path.isfile(config_json):
+    import json
+    with open(config_json, 'r') as configfile:
+        try:
+            config = json.load(configfile)
+        except Exception as e:
+            print(e)
+            exit()
+else:
+    config = {}
+
+for k in args.key:
+    if k in config:
+        config = config[k]
+    else:
+        if args.default != None:
+            print(args.default)
+            exit()
+
+print(config)

--- a/scripts/on_env_start.bat
+++ b/scripts/on_env_start.bat
@@ -12,6 +12,16 @@ if exist "scripts\user_config.bat" (
     @call scripts\user_config.bat
 )
 
+if exist "stable-diffusion\env" (
+    @set PYTHONPATH=%PYTHONPATH%;%cd%\stable-diffusion\env\lib\site-packages
+)
+
+if exist "scripts\get_config.py" (
+    @FOR /F "tokens=* USEBACKQ" %%F IN (`python scripts\get_config.py --default=main update_branch`) DO (
+        @SET update_branch=%%F
+    )
+)
+
 if "%update_branch%"=="" (
     set update_branch=main
 )
@@ -58,6 +68,7 @@ if "%update_branch%"=="" (
 @copy sd-ui-files\scripts\on_sd_start.bat scripts\ /Y
 @copy sd-ui-files\scripts\check_modules.py scripts\ /Y
 @copy sd-ui-files\scripts\check_models.py scripts\ /Y
+@copy sd-ui-files\scripts\get_config.py scripts\ /Y
 @copy "sd-ui-files\scripts\Start Stable Diffusion UI.cmd" . /Y
 @copy "sd-ui-files\scripts\Developer Console.cmd" . /Y
 

--- a/scripts/on_env_start.sh
+++ b/scripts/on_env_start.sh
@@ -12,6 +12,11 @@ if [ -f "scripts/user_config.sh" ]; then
     source scripts/user_config.sh
 fi
 
+export PYTHONPATH=$(pwd)/installer_files/env/lib/python3.8/site-packages:$(pwd)/stable-diffusion/env/lib/python3.8/site-packages
+
+if [ -f "scripts/get_config.py" ]; then
+   export update_branch="$( python scripts/get_config.py --default=main update_branch )"
+fi
 
 if [ "$update_branch" == "" ]; then
     export update_branch="main"
@@ -44,6 +49,7 @@ cp sd-ui-files/scripts/on_sd_start.sh scripts/
 cp sd-ui-files/scripts/bootstrap.sh scripts/
 cp sd-ui-files/scripts/check_modules.py scripts/
 cp sd-ui-files/scripts/check_models.py scripts/
+cp sd-ui-files/scripts/get_config.py scripts/
 cp sd-ui-files/scripts/start.sh .
 cp sd-ui-files/scripts/developer_console.sh .
 cp sd-ui-files/scripts/functions.sh scripts/

--- a/scripts/on_sd_start.bat
+++ b/scripts/on_sd_start.bat
@@ -104,14 +104,25 @@ call python --version
 
 @cd ..
 @set SD_UI_PATH=%cd%\ui
+
+@FOR /F "tokens=* USEBACKQ" %%F IN (`python scripts\get_config.py --default=9000 net listen_port`) DO (
+    @SET ED_BIND_PORT=%%F
+)
+
+@FOR /F "tokens=* USEBACKQ" %%F IN (`python scripts\get_config.py --default=False net listen_to_network`) DO (
+    if "%%F" EQU "True" (
+        @SET ED_BIND_IP=0.0.0.0    
+    ) else (
+        @SET ED_BIND_IP=127.0.0.1
+    )
+)
+
 @cd stable-diffusion
 
 @rem set any overrides
 set HF_HUB_DISABLE_SYMLINKS_WARNING=true
 
-@if NOT DEFINED SD_UI_BIND_PORT set SD_UI_BIND_PORT=9000
-@if NOT DEFINED SD_UI_BIND_IP set SD_UI_BIND_IP=0.0.0.0
-@uvicorn main:server_api --app-dir "%SD_UI_PATH%" --port %SD_UI_BIND_PORT% --host %SD_UI_BIND_IP% --log-level error
+@uvicorn main:server_api --app-dir "%SD_UI_PATH%" --port %ED_BIND_PORT% --host %ED_BIND_IP% --log-level error
 
 
 @pause

--- a/scripts/on_sd_start.bat
+++ b/scripts/on_sd_start.bat
@@ -7,6 +7,7 @@
 @copy sd-ui-files\scripts\bootstrap.bat scripts\ /Y
 @copy sd-ui-files\scripts\check_modules.py scripts\ /Y
 @copy sd-ui-files\scripts\check_models.py scripts\ /Y
+@copy sd-ui-files\scripts\get_config.py scripts\ /Y
 
 if exist "%cd%\profile" (
     set USERPROFILE=%cd%\profile

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -74,8 +74,17 @@ python --version
 
 cd ..
 export SD_UI_PATH=`pwd`/ui
+export ED_BIND_PORT="$( python scripts/get_config.py --default=9000 net listen_port )"
+case "$( python scripts/get_config.py --default=False net listen_to_network )" in
+    "True")
+        export ED_BIND_IP=0.0.0.0
+        ;;
+    "False")
+        export ED_BIND_IP=127.0.0.1
+        ;;
+esac
 cd stable-diffusion
 
-uvicorn main:server_api --app-dir "$SD_UI_PATH" --port ${SD_UI_BIND_PORT:-9000} --host ${SD_UI_BIND_IP:-0.0.0.0} --log-level error
+uvicorn main:server_api --app-dir "$SD_UI_PATH" --port "$ED_BIND_PORT" --host "$ED_BIND_IP" --log-level error
 
 read -p "Press any key to continue"

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -5,6 +5,7 @@ cp sd-ui-files/scripts/on_env_start.sh scripts/
 cp sd-ui-files/scripts/bootstrap.sh scripts/
 cp sd-ui-files/scripts/check_modules.py scripts/
 cp sd-ui-files/scripts/check_models.py scripts/
+cp sd-ui-files/scripts/get_config.py scripts/
 
 source ./scripts/functions.sh
 

--- a/ui/easydiffusion/app.py
+++ b/ui/easydiffusion/app.py
@@ -101,51 +101,6 @@ def setConfig(config):
     except:
         log.error(traceback.format_exc())
 
-    try:  # config.bat
-        config_bat_path = os.path.join(CONFIG_DIR, "config.bat")
-        config_bat = []
-
-        if "update_branch" in config:
-            config_bat.append(f"@set update_branch={config['update_branch']}")
-
-        config_bat.append(f"@set SD_UI_BIND_PORT={config['net']['listen_port']}")
-        bind_ip = "0.0.0.0" if config["net"]["listen_to_network"] else "127.0.0.1"
-        config_bat.append(f"@set SD_UI_BIND_IP={bind_ip}")
-
-        # Preserve these variables if they are set
-        for var in PRESERVE_CONFIG_VARS:
-            if os.getenv(var) is not None:
-                config_bat.append(f"@set {var}={os.getenv(var)}")
-
-        if len(config_bat) > 0:
-            with open(config_bat_path, "w", encoding="utf-8") as f:
-                f.write("\n".join(config_bat))
-    except:
-        log.error(traceback.format_exc())
-
-    try:  # config.sh
-        config_sh_path = os.path.join(CONFIG_DIR, "config.sh")
-        config_sh = ["#!/bin/bash"]
-
-        if "update_branch" in config:
-            config_sh.append(f"export update_branch={config['update_branch']}")
-
-        config_sh.append(f"export SD_UI_BIND_PORT={config['net']['listen_port']}")
-        bind_ip = "0.0.0.0" if config["net"]["listen_to_network"] else "127.0.0.1"
-        config_sh.append(f"export SD_UI_BIND_IP={bind_ip}")
-
-        # Preserve these variables if they are set
-        for var in PRESERVE_CONFIG_VARS:
-            if os.getenv(var) is not None:
-                config_bat.append(f'export {var}="{shlex.quote(os.getenv(var))}"')
-
-        if len(config_sh) > 1:
-            with open(config_sh_path, "w", encoding="utf-8") as f:
-                f.write("\n".join(config_sh))
-    except:
-        log.error(traceback.format_exc())
-
-
 def save_to_config(ckpt_model_name, vae_model_name, hypernetwork_model_name, vram_usage_level):
     config = getConfig()
     if "model" not in config:


### PR DESCRIPTION
Introduces scripts/get_config.py.
> usage: get_config.py [-h] [--default=DEFAULT] key [key ...]

If config.yaml exists, it will use that file. If it doesn't exist, it will look for config.json.

Get the update_branch setting from the config:
`python scripts/get_config.py update_branch`

Get net.listen_port:
`python scripts/get_config.py net listen_port`

Get the net.listen_to_network setting, return False if the setting doesn't exist in the config file:
`python scripts/get_config.py --default=False net listen_to_network`




