### PR TITLE
Don't use python packages from the user's home directory

### DIFF
--- a/scripts/on_env_start.sh
+++ b/scripts/on_env_start.sh
@@ -4,6 +4,8 @@ source ./scripts/functions.sh
 
 printf "\n\nEasy Diffusion\n\n"
 
+export PYTHONNOUSERSITE=y
+
 if [ -f "scripts/config.sh" ]; then
     source scripts/config.sh
 fi


### PR DESCRIPTION
PYTHONNOUSERSITE is required to ignore packages installed to `/home/user/.local/`. Since these folders are outside of our control, they can cause conflicts in ED's python env.

https://discord.com/channels/1014774730907209781/1100375010650103808

Fixes #1193