### PR TITLE
Disable "TypedStorage is deprecated" user warnings

### DIFF
--- a/ui/easydiffusion/app.py
+++ b/ui/easydiffusion/app.py
@@ -5,6 +5,7 @@ import socket
 import sys
 import traceback
 import urllib
+import warnings
 
 from easydiffusion import task_manager
 from easydiffusion.utils import log
@@ -86,6 +87,9 @@ def init():
     os.makedirs(USER_UI_PLUGINS_DIR, exist_ok=True)
     os.makedirs(USER_SERVER_PLUGINS_DIR, exist_ok=True)
 
+    # https://pytorch.org/docs/stable/storage.html
+    warnings.filterwarnings('ignore', category=UserWarning, message='TypedStorage is deprecated')
+    
     load_server_plugins()
 
     update_render_threads()


### PR DESCRIPTION
These warnings clog up the logfiles and worry users.

```
G:\stable-diffusion-ui\stable-diffusion\env\lib\site-packages\sdkit\models\model_loader\stable_diffusion\convert_from_ckpt.py:1084: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
  with safe_open(checkpoint_path, framework="pt", device="cpu") as f:
G:\stable-diffusion-ui\stable-diffusion\env\lib\site-packages\torch_utils.py:776: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
  return self.fget.get(instance, owner)()
G:\stable-diffusion-ui\stable-diffusion\env\lib\site-packages\torch\storage.py:899: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
  storage = cls(wrap_storage=untyped_storage) 
```