### PR TITLE
Add DDPM and DEIS samplers for diffusers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Just delete the `EasyDiffusion` folder to uninstall all the downloaded packages.
 
 ### Image generation
 - **Supports**: "*Text to Image*" and "*Image to Image*".
-- **19 Samplers**: `ddim`, `plms`, `heun`, `euler`, `euler_a`, `dpm2`, `dpm2_a`, `lms`, `dpm_solver_stability`, `dpmpp_2s_a`, `dpmpp_2m`, `dpmpp_sde`, `dpm_fast`, `dpm_adaptive`, `unipc_snr`, `unipc_tu`, `unipc_tq`, `unipc_snr_2`, `unipc_tu_2`.
+- **21 Samplers**: `ddim`, `plms`, `heun`, `euler`, `euler_a`, `dpm2`, `dpm2_a`, `lms`, `dpm_solver_stability`, `dpmpp_2s_a`, `dpmpp_2m`, `dpmpp_sde`, `dpm_fast`, `dpm_adaptive`, `ddpm`, `deis`, `unipc_snr`, `unipc_tu`, `unipc_tq`, `unipc_snr_2`, `unipc_tu_2`.
 - **In-Painting**: Specify areas of your image to paint into.
 - **Simple Drawing Tool**: Draw basic images to guide the AI, without needing an external drawing program.
 - **Face Correction (GFPGAN)**

--- a/ui/index.html
+++ b/ui/index.html
@@ -154,16 +154,18 @@
                             <option value="dpm2_a">DPM2 Ancestral</option>
                             <option value="lms">LMS</option>
                             <option value="dpm_solver_stability">DPM Solver (Stability AI)</option>
-                            <option value="dpmpp_2s_a">DPM++ 2s Ancestral (Karras)</option>
+                            <option value="dpmpp_2s_a" class="k_diffusion-only">DPM++ 2s Ancestral (Karras)</option>
                             <option value="dpmpp_2m">DPM++ 2m (Karras)</option>
-                            <option value="dpmpp_sde">DPM++ SDE (Karras)</option>
-                            <option value="dpm_fast">DPM Fast (Karras)</option>
-                            <option value="dpm_adaptive">DPM Adaptive (Karras)</option>
-                            <option value="unipc_snr">UniPC SNR</option>
-                            <option value="unipc_tu">UniPC TU</option>
-                            <option value="unipc_snr_2">UniPC SNR 2</option>
+                            <option value="dpmpp_sde" class="k_diffusion-only">DPM++ SDE (Karras)</option>
+                            <option value="dpm_fast" class="k_diffusion-only">DPM Fast (Karras)</option>
+                            <option value="dpm_adaptive" class="k_diffusion-only">DPM Adaptive (Karras)</option>
+                            <option value="ddpm" class="diffusers-only">DDPM</option>
+                            <option value="deis" class="diffusers-only">DEIS</option>
+                            <option value="unipc_snr" class="k_diffusion-only">UniPC SNR</option>
+                            <option value="unipc_tu" class="k_diffusion-only">UniPC TU</option>
+                            <option value="unipc_snr_2" class="k_diffusion-only">UniPC SNR 2</option>
                             <option value="unipc_tu_2">UniPC TU 2</option>
-                            <option value="unipc_tq">UniPC TQ</option>
+                            <option value="unipc_tq" class="k_diffusion-only">UniPC TQ</option>
                         </select>
                         <a href="https://github.com/cmdr2/stable-diffusion-ui/wiki/How-to-Use#samplers" target="_blank"><i class="fa-solid fa-circle-question help-btn"><span class="simple-tooltip top-left">Click to learn more about samplers</span></i></a>
                     </td></tr>

--- a/ui/index.html
+++ b/ui/index.html
@@ -162,7 +162,7 @@
                             <option value="ddpm" class="diffusers-only">DDPM</option>
                             <option value="deis" class="diffusers-only">DEIS</option>
                             <option value="unipc_snr" class="k_diffusion-only">UniPC SNR</option>
-                            <option value="unipc_tu" class="k_diffusion-only">UniPC TU</option>
+                            <option value="unipc_tu">UniPC TU</option>
                             <option value="unipc_snr_2" class="k_diffusion-only">UniPC SNR 2</option>
                             <option value="unipc_tu_2">UniPC TU 2</option>
                             <option value="unipc_tq" class="k_diffusion-only">UniPC TQ</option>

--- a/ui/media/js/parameters.js
+++ b/ui/media/js/parameters.js
@@ -388,15 +388,24 @@ async function getAppConfig() {
         if (config.net && config.net.listen_port !== undefined) {
             listenPortField.value = config.net.listen_port
         }
-        if (config.test_diffusers === undefined || config.update_branch === "main") {
-            testDiffusers.checked = false
+
+        const testDiffusersEnabled = config.test_diffusers && config.update_branch !== "main"
+        testDiffusers.checked = testDiffusersEnabled
+
+        if (!testDiffusersEnabled) {
             document.querySelector("#lora_model_container").style.display = "none"
             document.querySelector("#lora_alpha_container").style.display = "none"
+
+            document.querySelectorAll("#sampler_name option.diffusers-only").forEach(option => {
+                option.style.display = "none"
+            })
         } else {
-            testDiffusers.checked = config.test_diffusers && config.update_branch !== "main"
-            document.querySelector("#lora_model_container").style.display = testDiffusers.checked ? "" : "none"
-            document.querySelector("#lora_alpha_container").style.display =
-                testDiffusers.checked && loraModelField.value !== "" ? "" : "none"
+            document.querySelector("#lora_model_container").style.display = ""
+            document.querySelector("#lora_alpha_container").style.display = loraModelField.value ? "" : "none"
+
+            document.querySelectorAll("#sampler_name option.k_diffusion-only").forEach(option => {
+                option.disabled = true
+            })
         }
 
         console.log("get config status response", config)


### PR DESCRIPTION
These new samplers will be hidden when diffusers is disabled.
Also, samplers that aren't implemented in diffusers yet will be disabled when using diffusers.

![image](https://github.com/cmdr2/stable-diffusion-ui/assets/8977984/8afb8042-8a73-4b60-b994-88f74ede1e82)

SDKit PR: https://github.com/easydiffusion/sdkit/pull/35