### PR TITLE
Fail gracefully if proc access isn't possible

### DIFF
--- a/scripts/check_modules.py
+++ b/scripts/check_modules.py
@@ -130,10 +130,13 @@ def include_cuda_versions(module_versions: tuple) -> tuple:
 
 def is_amd_on_linux():
     if os_name == "Linux":
-        with open("/proc/bus/pci/devices", "r") as f:
-            device_info = f.read()
-            if "amdgpu" in device_info and "nvidia" not in device_info:
-                return True
+        try:
+            with open("/proc/bus/pci/devices", "r") as f:
+                device_info = f.read()
+                if "amdgpu" in device_info and "nvidia" not in device_info:
+                    return True
+        except:
+            return False
 
     return False
 


### PR DESCRIPTION
Fixes:
```
  File "../scripts/check_modules.py", line 133, in is_amd_on_linux
    with open("/proc/bus/pci/devices", "r") as f:
PermissionError: [Errno 13] Permission denied: '/proc/bus/pci/devices'
```
https://discord.com/channels/1014774730907209781/1108542536429093005/1108755274669502586