### PR TITLE
Automatically use 'Low' when VRAM<4.5GB

### DIFF
--- a/ui/media/js/auto-save.js
+++ b/ui/media/js/auto-save.js
@@ -169,6 +169,22 @@ function loadSettings() {
             }
         })
         CURRENTLY_LOADING_SETTINGS = false
+    } else if (localStorage.length < 2) {
+        // localStorage is too short for OldSettings
+        // So this is likely the first time Easy Diffusion is running.
+        // Initialize vram_usage_level based on the available VRAM
+        function initGPUProfile(event) {
+            if (    "detail" in event 
+                && "active" in event.detail
+                && "cuda:0" in event.detail.active
+                && event.detail.active["cuda:0"].mem_total <4.5 )
+            {
+               vramUsageLevelField.value = "low"
+               vramUsageLevelField.dispatchEvent(new Event("change"))
+            }
+            document.removeEventListener("system_info_update", initGPUProfile)
+        }
+        document.addEventListener("system_info_update", initGPUProfile)
     } else {
         CURRENTLY_LOADING_SETTINGS = true
         tryLoadOldSettings()

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -239,7 +239,7 @@ function setServerStatus(event) {
             break
     }
     if (SD.serverState.devices) {
-        setDeviceInfo(SD.serverState.devices)
+        document.dispatchEvent(new CustomEvent("system_info_update", { detail: SD.serverState.devices}))
     }
 }
 

--- a/ui/media/js/parameters.js
+++ b/ui/media/js/parameters.js
@@ -586,7 +586,7 @@ async function getSystemInfo() {
             $("#use_gpus").val(activeDeviceIds)
         }
 
-        setDeviceInfo(devices)
+        document.dispatchEvent(new CustomEvent("system_info_update", { detail: devices}))
         setHostInfo(res["hosts"])
         let force = false
         if (res["enforce_output_dir"] !== undefined) {
@@ -657,3 +657,5 @@ saveSettingsBtn.addEventListener("click", function() {
     saveSettingsBtn.classList.add("active")
     Promise.all([savePromise, asyncDelay(300)]).then(() => saveSettingsBtn.classList.remove("active"))
 })
+
+document.addEventListener("system_info_update", (e) => setDeviceInfo(e.detail))


### PR DESCRIPTION
When starting EasyDiffusion for the first time, initialize vram_usage_level based on the amount of VRAM. If cuda:0 has less than 4.5GB, switch to "low".