### PR TITLE
Network settings - Fix typo.

### DIFF
--- a/ui/media/js/parameters.js
+++ b/ui/media/js/parameters.js
@@ -181,8 +181,8 @@ var PARAMETERS = [
     {
         id: "listen_to_network",
         type: ParameterType.checkbox,
-        label: "Make Stable Diffusion available on your network. Please restart the program after changing this.",
-        note: "Other devices on your network can access this web page",
+        label: "Make Stable Diffusion available on your network",
+        note: "Other devices on your network can access this web page. Please restart the program after changing this.",
         icon: "fa-network-wired",
         default: true,
         saveInAppConfig: true,


### PR DESCRIPTION
The 'Please restart' text should be part of the note, not the label.
### Old
![image](https://github.com/cmdr2/stable-diffusion-ui/assets/5852422/d72430ea-24db-42ff-9e95-0f56bee9b21d)
