### PR TITLE
Fix confirmation dialog

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -264,7 +264,7 @@ function shiftOrConfirm(e, prompt, fn) {
         confirm(
             '<small>Tip: To skip this dialog, use shift-click or disable the "Confirm dangerous actions" setting in the Settings tab.</small>',
             prompt,
-            fn
+            () => { fn(e) }
         )
     }
 }

--- a/ui/media/js/utils.js
+++ b/ui/media/js/utils.js
@@ -918,9 +918,7 @@ function confirm(msg, title, fn) {
         animateFromElement: false,
         content: msg,
         buttons: {
-            yes: () => {
-                fn(e)
-            },
+            yes: fn,
             cancel: () => {},
         },
     })


### PR DESCRIPTION
By splitting the confirmation function into two halves, the closure was lost.

https://discord.com/channels/1014774730907209781/1110971052546334791