### PR TITLE
Fix regression in restore task to UI flow

### DIFF
--- a/ui/media/js/dnd.js
+++ b/ui/media/js/dnd.js
@@ -43,7 +43,6 @@ const TASK_MAPPING = {
         name: "Prompt",
         setUI: (prompt) => {
             promptField.value = prompt
-            promptField.dispatchEvent(new Event("input"))
         },
         readUI: () => promptField.value,
         parse: (val) => val,
@@ -422,6 +421,7 @@ function restoreTaskToUI(task, fieldsToSkip) {
     if (!("original_prompt" in task.reqBody)) {
         promptField.value = task.reqBody.prompt
     }
+    promptField.dispatchEvent(new Event("input"))
 
     // properly reset checkboxes
     if (!("use_face_correction" in task.reqBody)) {


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/cmdr2/stable-diffusion-ui/pull/1304 that causes the entire prompt to be restored in the prompt textbox, including the image modifiers, when restoring a task, reusing settings, etc.

Repro steps:
1. Create a task made solely of image modifiers (empty or partial prompt).
2. Start the rendering.
3. Click on Reuse settings.

Expected behavior:
The task is recreated identical to the original, including an empty/partial prompt textbox.

Actual behavior:
The entire prompt built from image modifiers is restored in the prompt textbox (in addition to restoring the image modifiers).
