### PR TITLE
Removed references to Python 3.8 in unix startup files.

### DIFF
--- a/scripts/developer_console.sh
+++ b/scripts/developer_console.sh
@@ -1,4 +1,15 @@
-#!/bin/bash
+#!/bin/env bash
+#setup legacy enviroment
+if [ -e "installer_files/env" ]; then
+	export ENVFOLDER="$(pwd)/installer_files/env"
+	export PATH="${ENVFOLDER}/bin:$PATH"; 
+	# check python version und adjust PYTHONPATH
+	if [ -e "${ENVFOLDER}/bin/python"]; then
+		export PYTHONVERSION="$(${ENVFOLDER}/bin/python --version | sed -e 's/Python//;s/\.[[:digit:]]*$//')"
+		export PYTHONPATH="${ENVFOLDER}/lib/python${PATHONVERSION}/site-packages"
+	fi
+fi
+
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
@@ -8,7 +19,6 @@ if [ "$0" == "bash" ]; then
 
   # set legacy and new installer's PATH, if they exist
   if [ -e "installer" ]; then export PATH="$(pwd)/installer/bin:$PATH"; fi
-  if [ -e "installer_files/env" ]; then export PATH="$(pwd)/installer_files/env/bin:$PATH"; fi
 
   # activate the installer env
   CONDA_BASEPATH=$(conda info --base)
@@ -26,17 +36,14 @@ if [ "$0" == "bash" ]; then
 
   echo ""
 
-  # activate the legacy environment (if present) and set PYTHONPATH
-  if [ -e "installer_files/env" ]; then
-    export PYTHONPATH="$(pwd)/installer_files/env/lib/python3.8/site-packages"
-  fi
+  # activate the legacy environment (if present) 
   if [ -e "stable-diffusion/env" ]; then
     CONDA_BASEPATH=$(conda info --base)
     source "$CONDA_BASEPATH/etc/profile.d/conda.sh" # otherwise conda complains about 'shell not initialized' (needed when running in a script)
 
     conda activate ./stable-diffusion/env
 
-    export PYTHONPATH="$(pwd)/stable-diffusion/env/lib/python3.8/site-packages"
+    export PYTHONPATH="$(pwd)/stable-diffusion/env/lib/python${PYTHONVERSION}/site-packages"
   fi
 
   export PYTHONNOUSERSITE=y

--- a/scripts/developer_console.sh
+++ b/scripts/developer_console.sh
@@ -5,7 +5,7 @@ if [ -e "installer_files/env" ]; then
 	export PATH="${ENVFOLDER}/bin:$PATH"; 
 	# check python version und adjust PYTHONPATH
 	if [ -e "${ENVFOLDER}/bin/python"]; then
-		export PYTHONVERSION="$(${ENVFOLDER}/bin/python --version | sed -e 's/Python//;s/\.[[:digit:]]*$//')"
+		export PYTHONVERSION="$(${ENVFOLDER}/bin/python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
 		export PYTHONPATH="${ENVFOLDER}/lib/python${PATHONVERSION}/site-packages"
 	fi
 fi

--- a/scripts/developer_console.sh
+++ b/scripts/developer_console.sh
@@ -43,7 +43,7 @@ if [ "$0" == "bash" ]; then
 
     conda activate ./stable-diffusion/env
 
-    export PYTHONPATH="$(pwd)/stable-diffusion/env/lib/python${PYTHONVERSION}/site-packages"
+    export PYTHONPATH="$(pwd)/stable-diffusion/env/lib/python3.8/site-packages"
   fi
 
   export PYTHONNOUSERSITE=y

--- a/scripts/developer_console.sh
+++ b/scripts/developer_console.sh
@@ -1,5 +1,5 @@
 #!/bin/env bash
-#setup legacy enviroment
+#setup enviroment
 if [ -e "installer_files/env" ]; then
 	export ENVFOLDER="$(pwd)/installer_files/env"
 	export PATH="${ENVFOLDER}/bin:$PATH"; 

--- a/scripts/on_env_start.sh
+++ b/scripts/on_env_start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/env bash
 
 source ./scripts/functions.sh
 
@@ -13,8 +13,16 @@ fi
 if [ -f "scripts/user_config.sh" ]; then
     source scripts/user_config.sh
 fi
-
-export PYTHONPATH=$(pwd)/installer_files/env/lib/python3.8/site-packages:$(pwd)/stable-diffusion/env/lib/python3.8/site-packages
+#setup legacy enviroment
+if [ -e "installer_files/env" ]; then
+	export ENVFOLDER="$(pwd)/installer_files/env"
+	export PATH="${ENVFOLDER}/bin:$PATH"; 
+	# check python version und adjust PYTHONPATH
+	if [ -e "${ENVFOLDER}/bin/python"]; then
+		export PYTHONVERSION="$(${ENVFOLDER}/bin/python --version | sed -e 's/Python//;s/\.[[:digit:]]*$//')"
+		export PYTHONPATH="${ENVFOLDER}/lib/python${PATHONVERSION}/site-packages"
+	fi
+fi
 
 if [ -f "scripts/get_config.py" ]; then
    export update_branch="$( python scripts/get_config.py --default=main update_branch )"

--- a/scripts/on_env_start.sh
+++ b/scripts/on_env_start.sh
@@ -23,6 +23,9 @@ if [ -e "installer_files/env" ]; then
 		export PYTHONPATH="${ENVFOLDER}/lib/python${PATHONVERSION}/site-packages"
 	fi
 fi
+if [ -e "stable-diffusion/env" ]; then
+	export PYTHONPATH="$(pwd)/stable-diffusion/env/lib/python3.8/site-packages"
+fi
 
 if [ -f "scripts/get_config.py" ]; then
    export update_branch="$( python scripts/get_config.py --default=main update_branch )"

--- a/scripts/on_env_start.sh
+++ b/scripts/on_env_start.sh
@@ -19,7 +19,7 @@ if [ -e "installer_files/env" ]; then
 	export PATH="${ENVFOLDER}/bin:$PATH"; 
 	# check python version und adjust PYTHONPATH
 	if [ -e "${ENVFOLDER}/bin/python"]; then
-		export PYTHONVERSION="$(${ENVFOLDER}/bin/python --version | sed -e 's/Python//;s/\.[[:digit:]]*$//')"
+		export PYTHONVERSION="$(${ENVFOLDER}/bin/python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
 		export PYTHONPATH="${ENVFOLDER}/lib/python${PATHONVERSION}/site-packages"
 	fi
 fi

--- a/scripts/on_env_start.sh
+++ b/scripts/on_env_start.sh
@@ -13,7 +13,8 @@ fi
 if [ -f "scripts/user_config.sh" ]; then
     source scripts/user_config.sh
 fi
-#setup legacy enviroment
+
+# setup enviroment
 if [ -e "installer_files/env" ]; then
 	export ENVFOLDER="$(pwd)/installer_files/env"
 	export PATH="${ENVFOLDER}/bin:$PATH"; 
@@ -23,6 +24,8 @@ if [ -e "installer_files/env" ]; then
 		export PYTHONPATH="${ENVFOLDER}/lib/python${PATHONVERSION}/site-packages"
 	fi
 fi
+
+# setup legacy environment
 if [ -e "stable-diffusion/env" ]; then
 	export PYTHONPATH="$(pwd)/stable-diffusion/env/lib/python3.8/site-packages"
 fi


### PR DESCRIPTION
on_env_start.sh and developer_console.sh still exported PYTHONPATH for python 3.8, which is outdated, replaced with a more flexible approach. Also altered the shebangs to #!/usr/bin/env bash. 
TODO: fix the same issue in Windows startup files, I can't do ist, I havn't a testing environment for MS.