### PR TITLE
Allow backend_config env overrides; document and test

### DIFF
--- a/scripts/config.yaml.sample
+++ b/scripts/config.yaml.sample
@@ -15,6 +15,15 @@ ui:
 # beta version.
 update_branch: main
 
+# Advanced backend overrides (optional)
+# These are applied at startup by `scripts/check_modules.py` and exported as environment variables.
+#
+# backend_config:
+#   # Extra backend flags (example: cross-attention optimizations)
+#   COMMANDLINE_ARGS: "--opt-split-attention"
+#   # Force full precision (float32). Can help if you see corrupted/black outputs on some GPUs/backends.
+#   FORCE_FULL_PRECISION: "1"
+#
 # Set force_save_path to enforce an auto save path. Clients will not be able to change or
 # disable auto save when this option is set. Please adapt the path in the examples to your
 # needs.

--- a/scripts/test_backend_config_overrides.py
+++ b/scripts/test_backend_config_overrides.py
@@ -1,0 +1,41 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+def _load_check_modules():
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    module_path = repo_root / "scripts" / "check_modules.py"
+
+    spec = importlib.util.spec_from_file_location("check_modules", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load module spec for {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestBackendConfigEnvOverrides(unittest.TestCase):
+    def test_commandline_args_string(self):
+        check_modules = _load_check_modules()
+        env = {}
+
+        check_modules.apply_backend_config_env_overrides({"COMMANDLINE_ARGS": "--opt-split-attention"}, env=env)
+
+        self.assertEqual(env.get("COMMANDLINE_ARGS"), "--opt-split-attention")
+
+    def test_commandline_args_list(self):
+        check_modules = _load_check_modules()
+        env = {}
+
+        check_modules.apply_backend_config_env_overrides(
+            {"COMMANDLINE_ARGS": ["--opt-split-attention", "--foo=bar"]}, env=env
+        )
+
+        self.assertEqual(env.get("COMMANDLINE_ARGS"), "--opt-split-attention --foo=bar")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add allowlisted backend_config env overrides (COMMANDLINE_ARGS, FORCE_FULL_PRECISION) and apply at launch
- make scripts/check_modules.py import-safe and add helper for backend overrides
- document backend_config examples and add a unit test for COMMANDLINE_ARGS normalization

## Testing
- python scripts/test_backend_config_overrides.py