### PR TITLE
Fix macOS startup shebangs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # What's new?
 
 ## v4 (preview)
+* 4.3.1 - TBD - Fix macOS startup scripts that used `/bin/env` instead of `/usr/bin/env`.
 * 4.3.0 - 24 Apr 2026 - Support Ernie Image and Ernie Image Turbo. Fixes for Anima models. Fixed a bug in v4 where LoRAs in nested folders would fail to load.
 * 4.2.0 - 31 Mar 2026 - (Internal code changes) Merge v3.5 and v4 engine into the main branch. This brings back the streamlined release process of landing new features first in beta, and then merging into the main branch after testing.
 * 4.1.0 - 13 Feb 2026 - Add support for Flux2-Klein.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,6 @@
 # What's new?
 
 ## v4 (preview)
-* 4.3.1 - TBD - Fix macOS startup scripts that used `/bin/env` instead of `/usr/bin/env`.
 * 4.3.0 - 24 Apr 2026 - Support Ernie Image and Ernie Image Turbo. Fixes for Anima models. Fixed a bug in v4 where LoRAs in nested folders would fail to load.
 * 4.2.0 - 31 Mar 2026 - (Internal code changes) Merge v3.5 and v4 engine into the main branch. This brings back the streamlined release process of landing new features first in beta, and then merging into the main branch after testing.
 * 4.1.0 - 13 Feb 2026 - Add support for Flux2-Klein.

--- a/scripts/developer_console.sh
+++ b/scripts/developer_console.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 #setup environment
 if [ -e "installer_files/env" ]; then
 	export ENVFOLDER="$(pwd)/installer_files/env"

--- a/scripts/on_env_start.sh
+++ b/scripts/on_env_start.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 source ./scripts/functions.sh
 


### PR DESCRIPTION
## Summary

This fixes a macOS startup failure caused by two shell scripts using `/bin/env` in their shebangs.

On macOS, `env` is available at `/usr/bin/env`, so running `./start.sh` can fail when it hands off to `scripts/on_env_start.sh`:

```text
./start.sh: scripts/on_env_start.sh: /bin/env: bad interpreter: No such file or directory
```

Using `#!/usr/bin/env bash` is the portable form and works on both macOS and Linux. This appears to affect the current Unix startup scripts when they are executed directly.

## Changes

- Update `scripts/on_env_start.sh` to use `#!/usr/bin/env bash`
- Update `scripts/developer_console.sh` to use `#!/usr/bin/env bash`
- Add a short `CHANGES.md` entry

## Testing

Tested on:

- macOS 26.1, build 25B78
- Apple M1 / arm64

I checked the changed scripts with:

```sh
bash -n scripts/on_env_start.sh
bash -n scripts/developer_console.sh
bash -n scripts/start.sh
```

I also hit this locally on macOS before the change, then confirmed the startup path progressed after fixing the shebang.
